### PR TITLE
Enable container-based builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
 - 2.1.4
+cache: bundler
+sudo: false
 before_install:
 - travis_retry gem install bundler
 before_script:


### PR DESCRIPTION
Enable container-based builds on Travis: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Builds will start much more quickly, and it allows caching of gems between builds.