### PR TITLE
More robust spec request stubbing

### DIFF
--- a/spec/features/bins_spec.rb
+++ b/spec/features/bins_spec.rb
@@ -17,8 +17,7 @@ feature "Bins", :type => :feature do
       @bin = bin
       @match = match
 
-      uri = api_url("1.0/resources/items/send")
-      stub_request(:post, uri). with(:body => {"barcode"=>"#{@match.item.barcode}", "delivery_type"=>"send", "item_id"=>"#{@match.item.id}", "request_type"=>"doc_del", "source"=>"aleph", "transaction_num"=>"", "tray_code"=>"#{@match.item.tray.barcode}"}, :headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
+      stub_request(:post, api_send_url). with(:body => {"barcode"=>"#{@match.item.barcode}", "delivery_type"=>"send", "item_id"=>"#{@match.item.id}", "request_type"=>"doc_del", "source"=>"aleph", "transaction_num"=>"", "tray_code"=>"#{@match.item.tray.barcode}"}, :headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
     end
 

--- a/spec/features/bins_spec.rb
+++ b/spec/features/bins_spec.rb
@@ -17,7 +17,7 @@ feature "Bins", :type => :feature do
       @bin = bin
       @match = match
 
-      uri = Addressable::URI.parse "http://1.0/resources/items/send?auth_token=987654321"
+      uri = api_url("1.0/resources/items/send")
       stub_request(:post, uri). with(:body => {"barcode"=>"#{@match.item.barcode}", "delivery_type"=>"send", "item_id"=>"#{@match.item.id}", "request_type"=>"doc_del", "source"=>"aleph", "transaction_num"=>"", "tray_code"=>"#{@match.item.tray.barcode}"}, :headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
     end

--- a/spec/features/item_to_shelf_spec.rb
+++ b/spec/features/item_to_shelf_spec.rb
@@ -16,13 +16,11 @@ feature "Shelves", :type => :feature do
 
       login_user
 
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-
-      @stock_uri = api_url("1.0/resources/items/stock")
+      item_uri = api_item_url(@item)
 
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
 
-      stub_request(:post, @stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -151,9 +149,9 @@ feature "Shelves", :type => :feature do
       5.times do |i|
         item = FactoryGirl.create(:item, title: "Item #{i + 1}")
         @items << item
-        item_uri = api_url("1.0/resources/items/record", barcode: item.barcode)
+        item_uri = api_item_url(item)
         stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, :headers => {} } }
-        stub_request(:post, @stock_uri).
+        stub_request(:post, api_stock_url).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"TRAY-#{@shelf.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/features/item_to_shelf_spec.rb
+++ b/spec/features/item_to_shelf_spec.rb
@@ -16,13 +16,13 @@ feature "Shelves", :type => :feature do
 
       login_user
 
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
 
-      @uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+      @stock_uri = api_url("1.0/resources/items/stock")
 
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
 
-      stub_request(:post, @uri2).
+      stub_request(:post, @stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -151,9 +151,9 @@ feature "Shelves", :type => :feature do
       5.times do |i|
         item = FactoryGirl.create(:item, title: "Item #{i + 1}")
         @items << item
-        uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{item.barcode}"
-        stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, :headers => {} } }
-        stub_request(:post, @uri2).
+        item_uri = api_url("1.0/resources/items/record", barcode: item.barcode)
+        stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, :headers => {} } }
+        stub_request(:post, @stock_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"TRAY-#{@shelf.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -13,14 +13,12 @@ feature "Items", :type => :feature do
       @item = FactoryGirl.create(:item, tray: @tray, thickness: 1, title: 'ITEM 1', chron: 'TEST CHRON')
       @item2 = FactoryGirl.create(:item, tray: @tray2, thickness: 2, title: 'ITEM 2', chron: 'TEST CHRON2')
 
-      stock_uri = api_url("1.0/resources/items/stock")
-
-      stub_request(:post, stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+      item_uri = api_item_url(@item)
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
     end
 

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -13,15 +13,15 @@ feature "Items", :type => :feature do
       @item = FactoryGirl.create(:item, tray: @tray, thickness: 1, title: 'ITEM 1', chron: 'TEST CHRON')
       @item2 = FactoryGirl.create(:item, tray: @tray2, thickness: 2, title: 'ITEM 2', chron: 'TEST CHRON2')
 
-      uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+      stock_uri = api_url("1.0/resources/items/stock")
 
-      stub_request(:post, uri2).
+      stub_request(:post, stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
     end
 
     after(:each) do

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -11,13 +11,11 @@ feature "Trays", :type => :feature do
       @item = FactoryGirl.create(:item)
       @item2 = FactoryGirl.create(:item)
 
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-
-      @stock_uri = api_url("1.0/resources/items/stock")
+      item_uri = api_item_url(@item)
 
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
 
-      stub_request(:post, @stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -327,8 +325,7 @@ feature "Trays", :type => :feature do
     it "displays an item after successfully adding it to a tray" do
       @item = FactoryGirl.create(:item)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item).at_least :once
-      uri = api_url("1.0/resources/items/stock")
-      stub_request(:post, uri).
+      stub_request(:post, api_stock_url).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -349,8 +346,7 @@ feature "Trays", :type => :feature do
    it "displays information about a successful association made" do
       @item = FactoryGirl.create(:item)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item).at_least :once
-      uri = api_url("1.0/resources/items/stock")
-      stub_request(:post, uri).
+      stub_request(:post, api_stock_url).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -373,10 +369,9 @@ feature "Trays", :type => :feature do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item).at_least :once
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-      stock_uri = api_url("1.0/resources/items/stock")
+      item_uri = api_item_url(@item)
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -409,7 +404,7 @@ feature "Trays", :type => :feature do
       @tray2 = FactoryGirl.create(:tray)
       item = FactoryGirl.create(:item, tray: @tray2)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
-      stub_request(:post, @stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray2.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -457,13 +452,12 @@ feature "Trays", :type => :feature do
       expect(current_path).to eq(show_tray_item_path(:id => @tray.id))
       @items.each do |item|
         expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
-        item_uri = api_url("1.0/resources/items/record", barcode: item.barcode)
-        stock_uri = api_url("1.0/resources/items/stock")
+        item_uri = api_item_url(item)
         stub_request(:post, item_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
-        stub_request(:post, stock_uri).
+        stub_request(:post, api_stock_url).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -482,10 +476,9 @@ feature "Trays", :type => :feature do
     it "allows the user to remove an item from a tray" do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-      stock_uri = api_url("1.0/resources/items/stock")
+      item_uri = api_item_url(@item)
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -506,10 +499,9 @@ feature "Trays", :type => :feature do
     it "allows the user to finish with the current tray when processing items" do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-      stock_uri = api_url("1.0/resources/items/stock")
+      item_uri = api_item_url(@item)
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -529,10 +521,9 @@ feature "Trays", :type => :feature do
     it "allows the user to finish with the current tray when processing items via scan" do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
-      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-      stock_uri = api_url("1.0/resources/items/stock")
+      item_uri = api_item_url(@item)
       stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, stock_uri).
+      stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -563,13 +554,12 @@ feature "Trays", :type => :feature do
       expect(current_path).to eq(show_tray_item_path(:id => @tray.id))
       @items.each do |item|
         expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
-        item_uri = api_url("1.0/resources/items/record", barcode: item.barcode)
-        stock_uri = api_url("1.0/resources/items/stock")
+        item_uri = api_item_url(item)
         stub_request(:post, item_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
-        stub_request(:post, stock_uri).
+        stub_request(:post, api_stock_url).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -11,15 +11,13 @@ feature "Trays", :type => :feature do
       @item = FactoryGirl.create(:item)
       @item2 = FactoryGirl.create(:item)
 
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-      uri3 = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
 
-      @uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+      @stock_uri = api_url("1.0/resources/items/stock")
 
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:get, uri3). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
 
-      stub_request(:post, @uri2).
+      stub_request(:post, @stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -329,7 +327,7 @@ feature "Trays", :type => :feature do
     it "displays an item after successfully adding it to a tray" do
       @item = FactoryGirl.create(:item)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item).at_least :once
-      uri = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+      uri = api_url("1.0/resources/items/stock")
       stub_request(:post, uri).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -351,7 +349,7 @@ feature "Trays", :type => :feature do
    it "displays information about a successful association made" do
       @item = FactoryGirl.create(:item)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item).at_least :once
-      uri = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+      uri = api_url("1.0/resources/items/stock")
       stub_request(:post, uri).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -375,10 +373,10 @@ feature "Trays", :type => :feature do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item).at_least :once
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-      uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, uri2).
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+      stock_uri = api_url("1.0/resources/items/stock")
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:post, stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -411,7 +409,7 @@ feature "Trays", :type => :feature do
       @tray2 = FactoryGirl.create(:tray)
       item = FactoryGirl.create(:item, tray: @tray2)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
-      stub_request(:post, @uri2).
+      stub_request(:post, @stock_uri).
         with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray2.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -459,13 +457,13 @@ feature "Trays", :type => :feature do
       expect(current_path).to eq(show_tray_item_path(:id => @tray.id))
       @items.each do |item|
         expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
-        uri = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321&barcode=#{item.barcode}"
-        uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-        stub_request(:post, uri).
+        item_uri = api_url("1.0/resources/items/record", barcode: item.barcode)
+        stock_uri = api_url("1.0/resources/items/stock")
+        stub_request(:post, item_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
-        stub_request(:post, uri2).
+        stub_request(:post, stock_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -484,10 +482,10 @@ feature "Trays", :type => :feature do
     it "allows the user to remove an item from a tray" do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-      uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, uri2).
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+      stock_uri = api_url("1.0/resources/items/stock")
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:post, stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -508,10 +506,10 @@ feature "Trays", :type => :feature do
     it "allows the user to finish with the current tray when processing items" do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-      uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, uri2).
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+      stock_uri = api_url("1.0/resources/items/stock")
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:post, stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -531,10 +529,10 @@ feature "Trays", :type => :feature do
     it "allows the user to finish with the current tray when processing items via scan" do
       @item = FactoryGirl.create(:item)
       @tray = FactoryGirl.create(:tray)
-      uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-      uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-      stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
-      stub_request(:post, uri2).
+      item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+      stock_uri = api_url("1.0/resources/items/stock")
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:post, stock_uri).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -565,13 +563,13 @@ feature "Trays", :type => :feature do
       expect(current_path).to eq(show_tray_item_path(:id => @tray.id))
       @items.each do |item|
         expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
-        uri = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321&barcode=#{item.barcode}"
-        uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-        stub_request(:post, uri).
+        item_uri = api_url("1.0/resources/items/record", barcode: item.barcode)
+        stock_uri = api_url("1.0/resources/items/stock")
+        stub_request(:post, item_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
-        stub_request(:post, uri2).
+        stub_request(:post, stock_uri).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{@tray.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
           to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,4 +50,6 @@ RSpec.configure do |config|
 
   # For Devise testing
   config.include Devise::TestHelpers, type: :controller
+
+  config.include ApiUrlHelper
 end

--- a/spec/services/associate_tray_with_item_barcode_spec.rb
+++ b/spec/services/associate_tray_with_item_barcode_spec.rb
@@ -12,13 +12,11 @@ RSpec.describe AssociateTrayWithItemBarcode do
     @item2 = FactoryGirl.create(:item)
     @user = FactoryGirl.create(:user)
 
-    @item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-
-    stock_uri = api_url("1.0/resources/items/stock")
+    @item_uri = api_item_url(@item)
 
     stub_request(:get, @item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
 
-    stub_request(:post, stock_uri).
+    stub_request(:post, api_stock_url).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/services/associate_tray_with_item_barcode_spec.rb
+++ b/spec/services/associate_tray_with_item_barcode_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe AssociateTrayWithItemBarcode do
     @item2 = FactoryGirl.create(:item)
     @user = FactoryGirl.create(:user)
 
-    @uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
+    @item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
 
-    uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+    stock_uri = api_url("1.0/resources/items/stock")
 
-    stub_request(:get, @uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+    stub_request(:get, @item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
 
-    stub_request(:post, uri2).
+    stub_request(:post, stock_uri).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
@@ -51,7 +51,7 @@ RSpec.describe AssociateTrayWithItemBarcode do
 
   it "returns the item when it is successful" do
     expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item)
-    stub_request(:get, @uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+    stub_request(:get, @item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
     allow(@item).to receive(:save).and_return(true)
     expect(subject).to eq(@item)
   end

--- a/spec/services/item_path_spec.rb
+++ b/spec/services/item_path_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe ItemPath do
     @item = FactoryGirl.create(:item, tray: @tray)
     @item2 = FactoryGirl.create(:item)
 
-    item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-    item2_uri = api_url("1.0/resources/items/record", barcode: @item2.barcode)
+    item_uri = api_item_url(@item)
+    item2_uri = api_item_url(@item2)
 
     stub_request(:get, item_uri).
          with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).

--- a/spec/services/item_path_spec.rb
+++ b/spec/services/item_path_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe ItemPath do
     @item = FactoryGirl.create(:item, tray: @tray)
     @item2 = FactoryGirl.create(:item)
 
-    uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}"
-    uri2 = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item2.barcode}"
+    item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+    item2_uri = api_url("1.0/resources/items/record", barcode: @item2.barcode)
 
-    stub_request(:get, uri).
+    stub_request(:get, item_uri).
          with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).
          to_return(:status => 200, :body => '{"path":"http://bogus"}', :headers => {})
 
-    stub_request(:get, uri2).
+    stub_request(:get, item2_uri).
          with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).
          to_return(:status => 200, :body => '{"path":"http://bogus"}', :headers => {})
 

--- a/spec/services/item_restock_spec.rb
+++ b/spec/services/item_restock_spec.rb
@@ -13,14 +13,10 @@ RSpec.describe ItemRestock do
     @item2 = FactoryGirl.create(:item)
     @user = FactoryGirl.create(:user)
 
-    uri = api_url("1.0/resources/items/record")
-    uri2 = api_url("1.0/resources/items/stock")
-    item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
-    item2_uri = api_url("1.0/resources/items/record", barcode: @item2.barcode)
+    item_uri = api_item_url(@item)
+    item2_uri = api_item_url(@item2)
 
-    stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
-
-    stub_request(:post, uri2).
+    stub_request(:post, api_stock_url).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/services/item_restock_spec.rb
+++ b/spec/services/item_restock_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe ItemRestock do
     @item2 = FactoryGirl.create(:item)
     @user = FactoryGirl.create(:user)
 
-    uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321"
-    uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+    uri = api_url("1.0/resources/items/record")
+    uri2 = api_url("1.0/resources/items/stock")
+    item_uri = api_url("1.0/resources/items/record", barcode: @item.barcode)
+    item2_uri = api_url("1.0/resources/items/record", barcode: @item2.barcode)
 
     stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
 
@@ -22,13 +24,13 @@ RSpec.describe ItemRestock do
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
-    
-    stub_request(:get, "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item.barcode}").
+
+    stub_request(:get, item_uri).
        with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
 
-    stub_request(:get, "http://1.0/resources/items/record?auth_token=987654321&barcode=#{@item2.barcode}").
+    stub_request(:get, item2_uri).
        with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
-    
+
     @user_id = 1 # Just fake having a user here
   end
 

--- a/spec/services/item_restock_to_tray_spec.rb
+++ b/spec/services/item_restock_to_tray_spec.rb
@@ -13,11 +13,7 @@ RSpec.describe ItemRestockToTray do
     @item2 = FactoryGirl.create(:item)
     @user = FactoryGirl.create(:user)
 
-    uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321&barcode={barcode}"
-
-    uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
-
-    stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
+    uri2 = api_url("1.0/resources/items/stock")
 
     stub_request(:post, uri2).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},

--- a/spec/services/item_restock_to_tray_spec.rb
+++ b/spec/services/item_restock_to_tray_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe ItemRestockToTray do
     @item2 = FactoryGirl.create(:item)
     @user = FactoryGirl.create(:user)
 
-    uri2 = api_url("1.0/resources/items/stock")
-
-    stub_request(:post, uri2).
+    stub_request(:post, api_stock_url).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/services/stock_item_spec.rb
+++ b/spec/services/stock_item_spec.rb
@@ -11,12 +11,7 @@ RSpec.describe StockItem do
     @item2 = FactoryGirl.create(:item, thickness: 1)
     @user = FactoryGirl.create(:user)
 
-    uri = api_url("1.0/resources/items/record")
-    uri2 = api_url("1.0/resources/items/stock")
-
-    stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
-
-    stub_request(:post, uri2).
+    stub_request(:post, api_stock_url).
       with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }

--- a/spec/services/stock_item_spec.rb
+++ b/spec/services/stock_item_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe StockItem do
     @item2 = FactoryGirl.create(:item, thickness: 1)
     @user = FactoryGirl.create(:user)
 
-    uri = Addressable::URI.parse "http://1.0/resources/items/record?auth_token=987654321"
-    uri2 = Addressable::URI.parse "http://1.0/resources/items/stock?auth_token=987654321"
+    uri = api_url("1.0/resources/items/record")
+    uri2 = api_url("1.0/resources/items/stock")
 
     stub_request(:get, uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
 

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -11,4 +11,16 @@ module ApiUrlHelper
     end
     Addressable::URI.parse "#{base_url}#{path}?#{params}"
   end
+
+  def api_stock_url
+    api_url("1.0/resources/items/stock")
+  end
+
+  def api_send_url
+    api_url("1.0/resources/items/send")
+  end
+
+  def api_item_url(item)
+    api_url("1.0/resources/items/record", barcode: item.barcode)
+  end
 end

--- a/spec/support/api_url_helper.rb
+++ b/spec/support/api_url_helper.rb
@@ -1,0 +1,14 @@
+module ApiUrlHelper
+  def api_url(path, params_hash = {})
+    base_url = Rails.application.secrets.api_server || "http:/"
+    auth_token = Rails.application.secrets.api_token
+    unless path =~ /^\//
+      path = "/#{path}"
+    end
+    params = { auth_token: auth_token }.to_param
+    if params_hash.present?
+      params += "&#{params_hash.to_param}"
+    end
+    Addressable::URI.parse "#{base_url}#{path}?#{params}"
+  end
+end


### PR DESCRIPTION
Created spec helper to generate api urls based off the api configuration for the test environment.  This will prevent specs from breaking if the secrets.yml configuration is changed.