### PR TITLE
AIMS-209: Stock Items to Tray for invalid item throws error

### DIFF
--- a/app/services/destroy_item.rb
+++ b/app/services/destroy_item.rb
@@ -1,0 +1,17 @@
+class DestroyItem
+  attr_reader :item, :user
+
+  def self.call(item, user)
+    new(item, user).destroy
+  end
+
+  def initialize(item, user)
+    @item = item
+    @user = user
+  end
+
+  def destroy
+    item.destroy!
+    LogActivity.call(item, "Destroyed", nil, Time.now, user)
+  end
+end

--- a/app/services/log_activity.rb
+++ b/app/services/log_activity.rb
@@ -27,7 +27,7 @@ class LogActivity
 
     activity.action = @action
 
-    if @action != "Created"
+    if @location
       activity.location_barcode = @location.barcode
       activity.location_type = @location.class.to_s
 

--- a/db/migrate/20150623185029_drop_activity_log_constraints.rb
+++ b/db/migrate/20150623185029_drop_activity_log_constraints.rb
@@ -1,0 +1,10 @@
+class DropActivityLogConstraints < ActiveRecord::Migration
+  def change
+    remove_foreign_key :activity_logs, column: :object_item_id
+    remove_foreign_key :activity_logs, column: :object_tray_id
+    remove_foreign_key :activity_logs, column: :location_tray_id
+    remove_foreign_key :activity_logs, column: :location_shelf_id
+    remove_foreign_key :activity_logs, column: :location_bin_id
+    remove_foreign_key :activity_logs, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150529145205) do
+ActiveRecord::Schema.define(version: 20150623185029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,12 +166,6 @@ ActiveRecord::Schema.define(version: 20150529145205) do
 
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
-  add_foreign_key "activity_logs", "bins", column: "location_bin_id"
-  add_foreign_key "activity_logs", "items", column: "object_item_id"
-  add_foreign_key "activity_logs", "shelves", column: "location_shelf_id"
-  add_foreign_key "activity_logs", "trays", column: "location_tray_id"
-  add_foreign_key "activity_logs", "trays", column: "object_tray_id"
-  add_foreign_key "activity_logs", "users"
   add_foreign_key "batches", "users"
   add_foreign_key "issues", "users", column: "resolver_id"
   add_foreign_key "items", "bins"

--- a/spec/services/get_item_from_barcode_spec.rb
+++ b/spec/services/get_item_from_barcode_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe GetItemFromBarcode do
   subject { described_class.call(user.id, barcode) }
@@ -8,17 +8,17 @@ RSpec.describe GetItemFromBarcode do
   let(:user) { instance_double(User, username: "bob", id: 1) }
   let(:barcode) { 123456789 }
   let!(:data) { { "status" => api_response_status, "results" => item_attr } }
-  let(:item_attr) {
+  let(:item_attr) do
     {
-      "title"=>"Symphony no. 2, op. 16 : The four temperaments / Carl Nielsen.",
-      "author"=>"Nielsen, Carl, 1865-1931.",
-      "chron"=>"",
-      "bib_number"=>"001883956",
-      "isbn_issn"=>"0486418979",
-      "conditions"=>nil,
-      "call_number"=>"M 1001 .N5 S2 2002"
+      "title" => "Symphony no. 2, op. 16 : The four temperaments / Carl Nielsen.",
+      "author" => "Nielsen, Carl, 1865-1931.",
+      "chron" => "",
+      "bib_number" => "001883956",
+      "isbn_issn" => "0486418979",
+      "conditions" => nil,
+      "call_number" =>" M 1001 .N5 S2 2002"
     }
-  }
+  end
 
   before(:each) do
     allow(User).to receive(:find).and_return(user)
@@ -28,7 +28,7 @@ RSpec.describe GetItemFromBarcode do
   context "invalid barcode" do
     it "raises an error" do
       allow(IsItemBarcode).to receive(:call).and_return(false)
-      expect{ subject }.to raise_error
+      expect { subject }.to raise_error
     end
   end
 

--- a/spec/services/get_item_from_barcode_spec.rb
+++ b/spec/services/get_item_from_barcode_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe GetItemFromBarcode do
+  subject { described_class.call(user.id, barcode) }
+
+  let(:api_response_status) { 200 }
+  let(:item) { instance_double(Item, attributes: item_attr) }
+  let(:user) { instance_double(User, username: "bob", id: 1) }
+  let(:barcode) { 123456789 }
+  let!(:data) { { "status" => api_response_status, "results" => item_attr } }
+  let(:item_attr) {
+    {
+      "title"=>"Symphony no. 2, op. 16 : The four temperaments / Carl Nielsen.",
+      "author"=>"Nielsen, Carl, 1865-1931.",
+      "chron"=>"",
+      "bib_number"=>"001883956",
+      "isbn_issn"=>"0486418979",
+      "conditions"=>nil,
+      "call_number"=>"M 1001 .N5 S2 2002"
+    }
+  }
+
+  before(:each) do
+    allow(User).to receive(:find).and_return(user)
+    allow(ApiGetItemMetadata).to receive(:call).with(barcode).and_return(data)
+  end
+
+  context "invalid barcode" do
+    it "raises an error" do
+      allow(IsItemBarcode).to receive(:call).and_return(false)
+      expect{ subject }.to raise_error
+    end
+  end
+
+  context "given a valid item" do
+    it "updates the item with data from the api" do
+      expect(subject.attributes).to include(item.attributes)
+    end
+
+    it "logs the activity" do
+      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
+      expect(LogActivity).to receive(:call).with(anything, "UpdatedByAPI", anything, anything, anything).ordered
+      subject
+    end
+  end
+
+  context "given an invalid item" do
+    let(:api_response_status) { 404 }
+
+    it "logs an issue" do
+      expect(AddIssue).to receive(:call).with(user.id, barcode, "Item not found.")
+      subject
+    end
+
+    it "destroys the item" do
+      expect_any_instance_of(Item).to receive(:destroy!)
+      subject
+    end
+
+    it "logs the activity" do
+      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
+      expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
+      subject
+    end
+  end
+
+  context "unauthorized api request" do
+    let(:api_response_status) { 401 }
+
+    it "logs an issue" do
+      expect(AddIssue).to receive(:call).with(user.id, barcode, "Unauthorized - Check API Key.")
+      subject
+    end
+
+    it "destroys the item" do
+      expect_any_instance_of(Item).to receive(:destroy!)
+      subject
+    end
+
+    it "logs the activity" do
+      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
+      expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
+      subject
+    end
+  end
+
+  context "api time out" do
+    let(:api_response_status) { 599 }
+
+    it "logs an issue" do
+      expect(AddIssue).to receive(:call).with(user.id, barcode, "API Timeout.")
+      subject
+    end
+
+    it "destroys the item" do
+      expect_any_instance_of(Item).to receive(:destroy!)
+      subject
+    end
+
+    it "logs the activity" do
+      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
+      expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
+      subject
+    end
+  end
+end

--- a/spec/services/item_path_spec.rb
+++ b/spec/services/item_path_spec.rb
@@ -5,6 +5,8 @@ def h
 end
 
 RSpec.describe ItemPath do
+  let(:user) { instance_double(User, username: "bob", id: 1) }
+
   before(:each) do
     @tray = FactoryGirl.create(:tray)
     @tray2 = FactoryGirl.create(:tray)
@@ -24,6 +26,7 @@ RSpec.describe ItemPath do
 
 
     @user_id = 1 # Just fake having a user here
+    allow(User).to receive(:find).and_return(user)
   end
 
   it "returns a path for a valid item" do


### PR DESCRIPTION
Why: Application was throwing an exception anytime the user tried to stock an item to tray with an invalid item.
How: An FK constraint on the ActivityLog model was preventing the stubbed out item from being deleted. Since the log should keep track of all changes, deletes included, I removed the constraints and updated the application to additionally create a log entry when an Item is deleted and when it is updated using data from the API.