### PR TITLE
AIMS-113 Reduce activity log insert to once per restock event

### DIFF
--- a/app/services/associate_shelf_with_item_barcode.rb
+++ b/app/services/associate_shelf_with_item_barcode.rb
@@ -16,8 +16,14 @@ class AssociateShelfWithItemBarcode
     validate_input!
     user = User.find(user_id)
     tray = GetTrayFromBarcode.call("TRAY-#{@shelf.barcode}")
-    AssociateTrayWithShelfBarcode.call(tray, @shelf.barcode, user)
-    AssociateTrayWithItemBarcode.call(user_id, tray, barcode, thickness)
+    item = GetItemFromBarcode.call(user_id, barcode)
+
+    if tray.items.include?(item)
+      StockItem.call(item, user)
+    else
+      AssociateTrayWithShelfBarcode.call(tray, @shelf.barcode, user)
+      AssociateTrayWithItemBarcode.call(user_id, tray, barcode, thickness)
+    end
 
     tray
   end


### PR DESCRIPTION
**WHAT** There was some redundant object creation in the AssociateShelfWithItem service class. It was running the association code whether or not the association already existed and this was duplicating work as well as activity logging. I added a test to avoid that duplication.

**HOW** The test checks whether the association already exists, and if so, simply restocks the item.