### PR TITLE
AIMS-200: Change handling of unstocked/shipped items in Items to Tray form

### DIFF
--- a/app/views/trays/show_item.html.haml
+++ b/app/views/trays/show_item.html.haml
@@ -22,6 +22,7 @@
   %thead
     %tr
       %th= "#{@tray.items.count} Item(s)"
+      %th= 'Status'
       %th= 'Barcode'
       %th= 'Thickness'
       %th= 'Title'
@@ -29,12 +30,14 @@
   %tbody
     - @tray.items.each do |item|
       %tr
-        %td
+        %td{ style: "white-space:nowrap;" }
           = form_tag dissociate_tray_item_path(@tray) do |f|
             = hidden_field_tag :item_id, item.id
-            .actions
+            .actions{ style: "display: inline-block;" }
               = submit_tag 'Remove', class: 'btn btn-primary'
-              = submit_tag 'Unstock', class: 'btn btn-secondary'
+              - if(item.status == 'stocked')
+                = submit_tag 'Unstock', class: 'btn btn-secondary'
+        %td= item.status.titleize
         %td= item.barcode
         %td= item.thickness
         %td= item.title


### PR DESCRIPTION
Why: Currently, there is no way to differentiate between stocked, unstocked, and shipped items, and the Unstock button is always available even if an item has been shipped or already unstocked.
How: Added a status column to the form and changed the Unstock button to only appear when an item is stocked