### PR TITLE
API refactoring

### DIFF
--- a/app/models/api_response.rb
+++ b/app/models/api_response.rb
@@ -1,0 +1,28 @@
+class ApiResponse
+  attr_reader :status_code, :body
+
+  def initialize(status_code: status_code, body: body)
+    @status_code = status_code
+    @body = body.with_indifferent_access
+  end
+
+  def success?
+    status_code == 200
+  end
+
+  def error?
+    !success?
+  end
+
+  def not_found?
+    status_code == 404
+  end
+
+  def timeout?
+    status_code == 599
+  end
+
+  def unauthorized?
+    status_code == 401
+  end
+end

--- a/app/models/api_response.rb
+++ b/app/models/api_response.rb
@@ -3,7 +3,10 @@ class ApiResponse
 
   def initialize(status_code: status_code, body: body)
     @status_code = status_code
-    @body = body.with_indifferent_access
+    @body = body
+    if @body.is_a?(Hash)
+      @body = @body.with_indifferent_access
+    end
   end
 
   def success?

--- a/app/services/api_get_item_metadata.rb
+++ b/app/services/api_get_item_metadata.rb
@@ -7,7 +7,6 @@ class ApiGetItemMetadata
 
   def initialize(barcode)
     @barcode = barcode
-    @path = "/1.0/resources/items/record"
   end
 
   def get_data!
@@ -18,14 +17,11 @@ class ApiGetItemMetadata
   private
 
     def response
-      raw_results = ApiHandler.call("GET", @path, { barcode: barcode })
-      ApiResponse.new(status_code: raw_results["status"], body: response_data(raw_results["results"]))
-    rescue Timeout::Error => e
-      ApiResponse.new(status_code: 599, body: response_data())
+      response = ApiHandler.call("GET", "/1.0/resources/items/record", { barcode: barcode })
+      ApiResponse.new(status_code: response.status_code, body: response_data(response.body))
     end
 
     def response_data(data = {})
-      data = data.with_indifferent_access
       {
         title: data[:title],
         author: data[:author],

--- a/app/services/api_get_item_metadata.rb
+++ b/app/services/api_get_item_metadata.rb
@@ -12,6 +12,6 @@ class ApiGetItemMetadata
   end
 
   def get_data!
-    ApiHandler.get(API_PATH, { barcode: barcode })
+    ApiHandler.get(API_PATH, barcode: barcode)
   end
 end

--- a/app/services/api_get_item_metadata.rb
+++ b/app/services/api_get_item_metadata.rb
@@ -1,6 +1,4 @@
 class ApiGetItemMetadata
-  API_PATH = "/1.0/resources/items/record"
-
   attr_reader :barcode
 
   def self.call(barcode)
@@ -12,6 +10,6 @@ class ApiGetItemMetadata
   end
 
   def get_data!
-    ApiHandler.get(API_PATH, barcode: barcode)
+    ApiHandler.get(:record, barcode: barcode)
   end
 end

--- a/app/services/api_get_item_metadata.rb
+++ b/app/services/api_get_item_metadata.rb
@@ -1,4 +1,6 @@
 class ApiGetItemMetadata
+  API_PATH = "/1.0/resources/items/record"
+
   attr_reader :barcode
 
   def self.call(barcode)
@@ -10,35 +12,6 @@ class ApiGetItemMetadata
   end
 
   def get_data!
-    validate_input!
-    response
+    ApiHandler.get(API_PATH, { barcode: barcode })
   end
-
-  private
-
-    def response
-      response = ApiHandler.call("GET", "/1.0/resources/items/record", { barcode: barcode })
-      ApiResponse.new(status_code: response.status_code, body: response_data(response.body))
-    end
-
-    def response_data(data = {})
-      {
-        title: data[:title],
-        author: data[:author],
-        chron: data[:description],
-        bib_number: data[:bib_id],
-        isbn_issn: data[:isbn_issn],
-        conditions: data[:condition],
-        call_number: data[:call_number],
-      }
-    end
-
-    def validate_input!
-      if IsItemBarcode.call(barcode)
-        true
-      else
-        raise "barcode is not an item"
-      end
-    end
-
 end

--- a/app/services/api_get_item_metadata.rb
+++ b/app/services/api_get_item_metadata.rb
@@ -12,36 +12,30 @@ class ApiGetItemMetadata
 
   def get_data!
     validate_input!
-
-    params = "barcode=#{@barcode}"
-    begin
-      raw_results = ApiHandler.call("GET", @path, params)
-      results = {"status" => raw_results["status"], "results" => 
-        {
-          "title" => raw_results["results"]["title"],
-          "author" => raw_results["results"]["author"],
-          "chron" => raw_results["results"]["description"],
-          "bib_number" => raw_results["results"]["bib_id"],
-          "isbn_issn" => raw_results["results"]["isbn_issn"],
-          "conditions" => raw_results["results"]["condition"],
-          "call_number" => raw_results["results"]["call_number"]
-        }}
-    rescue Timeout::Error => e  # Status code 599 is a MS defined code for network timeout
-      results = {"status" => 599, "results" => 
-        {
-          "title" => nil,
-          "author" => nil,
-          "chron" => nil,
-          "bib_number" => nil,
-          "isbn_issn" => nil,
-          "conditions" => nil,
-          "call_number" => nil
-        }}
-    end
-    results
+    response
   end
 
   private
+
+    def response
+      raw_results = ApiHandler.call("GET", @path, { barcode: barcode })
+      ApiResponse.new(status_code: raw_results["status"], body: response_data(raw_results["results"]))
+    rescue Timeout::Error => e
+      ApiResponse.new(status_code: 599, body: response_data())
+    end
+
+    def response_data(data = {})
+      data = data.with_indifferent_access
+      {
+        title: data[:title],
+        author: data[:author],
+        chron: data[:description],
+        bib_number: data[:bib_id],
+        isbn_issn: data[:isbn_issn],
+        conditions: data[:condition],
+        call_number: data[:call_number],
+      }
+    end
 
     def validate_input!
       if IsItemBarcode.call(barcode)

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -1,6 +1,4 @@
 class ApiGetRequestList
-  API_PATH = "/1.0/resources/items/active_requests"
-
   attr_reader :user_id
 
   def self.call(user_id)
@@ -17,7 +15,7 @@ class ApiGetRequestList
 
     requests = []
 
-    response = ApiHandler.get(API_PATH, params)
+    response = ApiHandler.get(:active_requests, params)
     if response.success?
       requests = parse_requests(response.body[:requests])
     end

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -1,11 +1,14 @@
 class ApiGetRequestList
+  API_PATH = "/1.0/resources/items/active_requests"
+
+  attr_reader :user_id
+
   def self.call(user_id)
     new(user_id).get_data!
   end
 
   def initialize(user_id)
     @user_id = user_id
-    @path = "/1.0/resources/items/active_requests"
   end
 
   def get_data!
@@ -14,7 +17,7 @@ class ApiGetRequestList
 
     requests = []
 
-    response = ApiHandler.call("GET", @path, params)
+    response = ApiHandler.get(API_PATH, params)
     if response.success?
       requests = parse_requests(response.body[:requests])
     end
@@ -28,7 +31,7 @@ class ApiGetRequestList
       if !res["barcode"].blank?
         criteria_type = "barcode"
         criteria = res["barcode"]
-        item = GetItemFromBarcode.call(@user_id, res["barcode"]) # Hack to make sure data is present for display.
+        item = GetItemFromBarcode.call(user_id, res["barcode"]) # Hack to make sure data is present for display.
       elsif !res["bib_number"].blank?
         criteria_type = "bib_number"
         criteria = res["bib_number"]

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -49,7 +49,7 @@ class ApiGetRequestList
       del_type = res["delivery_type"].downcase
       source = res["source"].downcase
 
-      req_type = res["request_type"].include?(' ') ? res["request_type"].downcase.gsub!(' ','_') : res["request_type"].downcase
+      req_type = res["request_type"].include?(" ") ? res["request_type"].downcase.gsub!(" ","_") : res["request_type"].downcase
 
       if (res["rush"] == "No") || (res["rush"] == "Regular")
         rapid = false
@@ -57,13 +57,13 @@ class ApiGetRequestList
         rapid = true
       end
 
-      trans = (res["transaction"].include?('doc-del')? res["transaction"].gsub!('doc-del', 'aleph') : res["transaction"]).gsub!('-', '_')
+      trans = (res["transaction"].include?("doc-del")? res["transaction"].gsub!("doc-del", "aleph") : res["transaction"]).gsub!("-", "_")
 
       requests << { # Will add more info when rebuilding the batch page. Needs a migration.
         "trans" => trans,
         "criteria_type" => criteria_type,
         "criteria" => criteria,
-        "requested" => Date.today.to_s, # Should be date requested, but that doesn't seem available.
+        "requested" => Date.today.to_s, # Should be date requested, but that doesn"t seem available.
         "rapid" => rapid,
         "source" => source,
         "del_type" => del_type,

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -31,7 +31,7 @@ class ApiGetRequestList
       if !res["barcode"].blank?
         criteria_type = "barcode"
         criteria = res["barcode"]
-        item = GetItemFromBarcode.call(user_id, res["barcode"]) # Hack to make sure data is present for display.
+        GetItemFromBarcode.call(user_id, res["barcode"]) # Hack to make sure data is present for display.
       elsif !res["bib_number"].blank?
         criteria_type = "bib_number"
         criteria = res["bib_number"]

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -14,65 +14,66 @@ class ApiGetRequestList
 
     requests = []
 
-    begin
-      raw_results = ApiHandler.call("GET", @path, params)
-      raw_results["results"]["requests"].each do |res|
-        if !res["barcode"].blank?
-          criteria_type = "barcode"
-          criteria = res["barcode"]
-          item = GetItemFromBarcode.call(@user_id, res["barcode"]) # Hack to make sure data is present for display.
-        elsif !res["bib_number"].blank?
-          criteria_type = "bib_number"
-          criteria = res["bib_number"]
-        elsif !res["isbn_issn"].blank?
-          criteria_type = "isbn_issn"
-          criteria = res["isbn_issn"]
-        elsif !res["title"].blank?
-          criteria_type = "title"
-          criteria = res["title"]
-        else
-          criteria_type = "ERROR" # Quick hack to cover when not available.
-          criteria = "ERROR"
-        end
-
-        del_type = res["delivery_type"].downcase
-        source = res["source"].downcase
-
-        req_type = res["request_type"].include?(' ') ? res["request_type"].downcase.gsub!(' ','_') : res["request_type"].downcase
-
-        if (res["rush"] == "No") || (res["rush"] == "Regular")
-          rapid = false
-        else
-          rapid = true
-        end
-
-        trans = (res["transaction"].include?('doc-del')? res["transaction"].gsub!('doc-del', 'aleph') : res["transaction"]).gsub!('-', '_')
-
-        requests << { # Will add more info when rebuilding the batch page. Needs a migration.
-          "trans" => trans,
-          "criteria_type" => criteria_type,
-          "criteria" => criteria,
-          "requested" => Date.today.to_s, # Should be date requested, but that doesn't seem available.
-          "rapid" => rapid,
-          "source" => source,
-          "del_type" => del_type,
-          "req_type" => req_type,
-          "title" => res["title"],
-          "article_title" => res["article_title"],
-          "author" => res["author"],
-          "description" => res["description"],
-          "barcode" => res["barcode"],
-          "isbn_issn" => res["isbn_issn"],
-          "bib_number" => res["bib_number"]
-        }
-      end
-    rescue Timeout::Error => e
-      raw_results = {"status" => 599}
+    response = ApiHandler.call("GET", @path, params)
+    if response.success?
+      requests = parse_requests(response.body[:requests])
     end
 
-    results = {"status" => raw_results["status"], "results" => requests}
+    ApiResponse.new(status_code: response.status_code, body: requests)
+  end
 
-    results
+  def parse_requests(requests_data)
+    requests = []
+    requests_data.each do |res|
+      if !res["barcode"].blank?
+        criteria_type = "barcode"
+        criteria = res["barcode"]
+        item = GetItemFromBarcode.call(@user_id, res["barcode"]) # Hack to make sure data is present for display.
+      elsif !res["bib_number"].blank?
+        criteria_type = "bib_number"
+        criteria = res["bib_number"]
+      elsif !res["isbn_issn"].blank?
+        criteria_type = "isbn_issn"
+        criteria = res["isbn_issn"]
+      elsif !res["title"].blank?
+        criteria_type = "title"
+        criteria = res["title"]
+      else
+        criteria_type = "ERROR" # Quick hack to cover when not available.
+        criteria = "ERROR"
+      end
+
+      del_type = res["delivery_type"].downcase
+      source = res["source"].downcase
+
+      req_type = res["request_type"].include?(' ') ? res["request_type"].downcase.gsub!(' ','_') : res["request_type"].downcase
+
+      if (res["rush"] == "No") || (res["rush"] == "Regular")
+        rapid = false
+      else
+        rapid = true
+      end
+
+      trans = (res["transaction"].include?('doc-del')? res["transaction"].gsub!('doc-del', 'aleph') : res["transaction"]).gsub!('-', '_')
+
+      requests << { # Will add more info when rebuilding the batch page. Needs a migration.
+        "trans" => trans,
+        "criteria_type" => criteria_type,
+        "criteria" => criteria,
+        "requested" => Date.today.to_s, # Should be date requested, but that doesn't seem available.
+        "rapid" => rapid,
+        "source" => source,
+        "del_type" => del_type,
+        "req_type" => req_type,
+        "title" => res["title"],
+        "article_title" => res["article_title"],
+        "author" => res["author"],
+        "description" => res["description"],
+        "barcode" => res["barcode"],
+        "isbn_issn" => res["isbn_issn"],
+        "bib_number" => res["bib_number"]
+      }
+    end
   end
 
 end

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -49,7 +49,7 @@ class ApiGetRequestList
       del_type = res["delivery_type"].downcase
       source = res["source"].downcase
 
-      req_type = res["request_type"].include?(" ") ? res["request_type"].downcase.gsub!(" ","_") : res["request_type"].downcase
+      req_type = res["request_type"].downcase.gsub(" ", "_")
 
       if (res["rush"] == "No") || (res["rush"] == "Regular")
         rapid = false
@@ -57,7 +57,7 @@ class ApiGetRequestList
         rapid = true
       end
 
-      trans = (res["transaction"].include?("doc-del")? res["transaction"].gsub!("doc-del", "aleph") : res["transaction"]).gsub!("-", "_")
+      trans = res["transaction"].gsub("doc-del", "aleph").gsub("-", "_")
 
       requests << { # Will add more info when rebuilding the batch page. Needs a migration.
         "trans" => trans,

--- a/app/services/api_post_deliver_item.rb
+++ b/app/services/api_post_deliver_item.rb
@@ -13,11 +13,7 @@ class ApiPostDeliverItem
   end
 
   def post_data!
-    delivery_type = (match.request.del_type == "scan") ? "scan" : "send"
-
-    params = { item_id: match.item.id, barcode: match.item.barcode, tray_code: match.item.tray.barcode, source: match.request.source, transaction_num: match.request.trans, request_type: match.request.req_type, delivery_type: delivery_type}
-
-    response = ApiHandler.post(path(delivery_type), params)
+    response = ApiHandler.post(delivery_type, params)
 
     if delivery_type == "send"
       ShipItem.call(match.item, user)  # This is inside out from StockItem, but works better this way, I think.
@@ -27,6 +23,26 @@ class ApiPostDeliverItem
     end
 
     response
+  end
+
+  def params
+    {
+      item_id: match.item.id,
+      barcode: match.item.barcode,
+      tray_code: match.item.tray.barcode,
+      source: match.request.source,
+      transaction_num: match.request.trans,
+      request_type: match.request.req_type,
+      delivery_type: delivery_type
+    }
+  end
+
+  def delivery_type
+    if match.request.del_type == "scan"
+      "scan"
+    else
+      "send"
+    end
   end
 
   def path(delivery_type)

--- a/app/services/api_post_deliver_item.rb
+++ b/app/services/api_post_deliver_item.rb
@@ -1,4 +1,6 @@
 class ApiPostDeliverItem
+  API_PATH = "/1.0/resources/items/"
+
   attr_reader :match_id, :user
 
   def self.call(match_id, user)
@@ -12,11 +14,10 @@ class ApiPostDeliverItem
 
   def post_data!
     delivery_type = (match.request.del_type == "scan") ? "scan" : "send"
-    path = "/1.0/resources/items/#{delivery_type}"
 
     params = { item_id: match.item.id, barcode: match.item.barcode, tray_code: match.item.tray.barcode, source: match.request.source, transaction_num: match.request.trans, request_type: match.request.req_type, delivery_type: delivery_type}
 
-    response = ApiHandler.call("POST", path, params)
+    response = ApiHandler.post(path(delivery_type), params)
 
     if delivery_type == "send"
       ShipItem.call(match.item, user)  # This is inside out from StockItem, but works better this way, I think.
@@ -26,6 +27,10 @@ class ApiPostDeliverItem
     end
 
     response
+  end
+
+  def path(delivery_type)
+    "#{API_PATH}#{delivery_type}"
   end
 
   private

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -1,4 +1,6 @@
 class ApiPostStockItem
+  REQUEST_PATH = "/1.0/resources/items/stock"
+
   attr_reader :item_id
 
   def self.call(item_id)
@@ -7,21 +9,24 @@ class ApiPostStockItem
 
   def initialize(item_id)
     @item_id = item_id
-    @path = "/1.0/resources/items/stock"
   end
 
   def post_data!
-    item = Item.find(@item_id)
+    ApiHandler.call("POST", REQUEST_PATH, post_params)
+  end
 
-    params = {item_id: @item_id, barcode: item.barcode, tray_code: item.tray.barcode}
+  private
 
-    begin
-      raw_results = ApiHandler.call("POST", @path, params)
-    rescue Timeout::Error => e
-      raw_results = {"status"=>599, "results"=>{"status"=>"NETWORK CONNECT TIMEOUT ERROR", "message"=>"Timeout Error"}}
-    end
+  def post_params
+    {
+      item_id: item.id,
+      barcode: item.barcode,
+      tray_code: item.tray.barcode
+    }
+  end
 
-    raw_results
+  def item
+    @item ||= Item.find(item_id)
   end
 
 end

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -1,6 +1,4 @@
 class ApiPostStockItem
-  API_PATH = "/1.0/resources/items/stock"
-
   attr_reader :item_id
 
   def self.call(item_id)
@@ -12,7 +10,7 @@ class ApiPostStockItem
   end
 
   def post_data!
-    ApiHandler.post(API_PATH, post_params)
+    ApiHandler.post(:stock, post_params)
   end
 
   private

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -1,5 +1,5 @@
 class ApiPostStockItem
-  REQUEST_PATH = "/1.0/resources/items/stock"
+  API_PATH = "/1.0/resources/items/stock"
 
   attr_reader :item_id
 
@@ -12,7 +12,7 @@ class ApiPostStockItem
   end
 
   def post_data!
-    ApiHandler.call("POST", REQUEST_PATH, post_params)
+    ApiHandler.post(API_PATH, post_params)
   end
 
   private

--- a/app/services/external_rest_connection.rb
+++ b/app/services/external_rest_connection.rb
@@ -55,8 +55,14 @@ class ExternalRestConnection
       faraday_instance.request :url_encoded
       faraday_instance.response :json, content_type: /text\/plain/
       faraday_instance.response :xml,  content_type: /\bxml$/
-      faraday_instance.response :caching, file_cache, ignore_params: %w(access_token)
+      if cache_response?
+        faraday_instance.response :caching, file_cache, ignore_params: %w(access_token)
+      end
       faraday_instance.adapter :typhoeus
+  end
+
+  def cache_response?
+    !(Rails.env.test? || Rails.env.development?)
   end
 
   def file_cache

--- a/app/services/get_item_from_barcode.rb
+++ b/app/services/get_item_from_barcode.rb
@@ -22,8 +22,6 @@ class GetItemFromBarcode
 
       if SyncItemMetadata.call(item: item, user_id: user_id)
         item
-      else
-        nil
       end
     else
       raise "barcode is not an item"

--- a/app/services/get_item_from_barcode.rb
+++ b/app/services/get_item_from_barcode.rb
@@ -30,11 +30,11 @@ class GetItemFromBarcode
 
   private
 
-    def user
-      @user ||= User.find(user_id)
-    end
+  def user
+    @user ||= User.find(user_id)
+  end
 
-    def valid?
-      IsItemBarcode.call(barcode)
-    end
+  def valid?
+    IsItemBarcode.call(barcode)
+  end
 end

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -1,0 +1,56 @@
+class SyncItemMetadata
+  attr_reader :item, :user_id
+
+  def self.call(item: item, user_id: user_id)
+    new(item: item, user_id: user_id).sync
+  end
+
+  def initialize(item: item, user_id: user_id)
+    @item = item
+    @user_id = user_id
+  end
+
+  def sync
+    response = ApiGetItemMetadata.call(barcode)
+    if response.success?
+      save_metadata(response.body)
+      item
+      true
+    else
+      handle_error(response)
+      false
+    end
+  end
+
+  private
+
+    def user
+      @user ||= User.find(user_id)
+    end
+
+    def handle_error(response)
+      AddIssue.call(user_id, barcode, error_message(response))
+      DestroyItem.call(item, user)
+    end
+
+    def error_message(response)
+      if response.not_found?
+        "Item not found."
+      elsif response.unauthorized?
+        "Unauthorized - Check API Key."
+      elsif response.timeout?
+        "API Timeout."
+      else
+        "Error #{response.status_code}"
+      end
+    end
+
+    def save_metadata(data)
+      item.update!(data)
+      LogActivity.call(item, "UpdatedByAPI", nil, Time.now, user)
+    end
+
+    def barcode
+      item.barcode
+    end
+end

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -24,45 +24,45 @@ class SyncItemMetadata
 
   private
 
-    def user
-      @user ||= User.find(user_id)
-    end
+  def user
+    @user ||= User.find(user_id)
+  end
 
-    def handle_error(response)
-      AddIssue.call(user_id, barcode, error_message(response))
-      DestroyItem.call(item, user)
-    end
+  def handle_error(response)
+    AddIssue.call(user_id, barcode, error_message(response))
+    DestroyItem.call(item, user)
+  end
 
-    def error_message(response)
-      if response.not_found?
-        "Item not found."
-      elsif response.unauthorized?
-        "Unauthorized - Check API Key."
-      elsif response.timeout?
-        "API Timeout."
-      else
-        "Error #{response.status_code}"
-      end
+  def error_message(response)
+    if response.not_found?
+      "Item not found."
+    elsif response.unauthorized?
+      "Unauthorized - Check API Key."
+    elsif response.timeout?
+      "API Timeout."
+    else
+      "Error #{response.status_code}"
     end
+  end
 
-    def map_item_attributes(data)
-      {
-        title: data[:title],
-        author: data[:author],
-        chron: data[:description],
-        bib_number: data[:bib_id],
-        isbn_issn: data[:isbn_issn],
-        conditions: data[:condition],
-        call_number: data[:call_number],
-      }
-    end
+  def map_item_attributes(data)
+    {
+      title: data[:title],
+      author: data[:author],
+      chron: data[:description],
+      bib_number: data[:bib_id],
+      isbn_issn: data[:isbn_issn],
+      conditions: data[:condition],
+      call_number: data[:call_number],
+    }
+  end
 
-    def save_metadata(data)
-      item.update!(map_item_attributes(data))
-      LogActivity.call(item, "UpdatedByAPI", nil, Time.now, user)
-    end
+  def save_metadata(data)
+    item.update!(map_item_attributes(data))
+    LogActivity.call(item, "UpdatedByAPI", nil, Time.now, user)
+  end
 
-    def barcode
-      item.barcode
-    end
+  def barcode
+    item.barcode
+  end
 end

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -45,8 +45,20 @@ class SyncItemMetadata
       end
     end
 
+    def map_item_attributes(data)
+      {
+        title: data[:title],
+        author: data[:author],
+        chron: data[:description],
+        bib_number: data[:bib_id],
+        isbn_issn: data[:isbn_issn],
+        conditions: data[:condition],
+        call_number: data[:call_number],
+      }
+    end
+
     def save_metadata(data)
-      item.update!(data)
+      item.update!(map_item_attributes(data))
       LogActivity.call(item, "UpdatedByAPI", nil, Time.now, user)
     end
 

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -75,7 +75,7 @@ feature "Items", :type => :feature do
 
     it "can view a list of issues associated with retrieving item data" do
       @issues = []
-      10.times do
+      5.times do
         @issue = FactoryGirl.create(:issue)
         @issues << @issue
       end
@@ -90,7 +90,7 @@ feature "Items", :type => :feature do
 
     it "can view a list of issues associated with retrieving item data and delete them" do
       @issues = []
-      10.times do
+      5.times do
         @issue = FactoryGirl.create(:issue)
         @issues << @issue
       end

--- a/spec/fixtures/api/active_requests.json
+++ b/spec/fixtures/api/active_requests.json
@@ -1,0 +1,50 @@
+{
+  "requests":[
+    {
+      "transaction":"illiad-85132100",
+      "request_date_time":"2015-05-05T08:46:00Z",
+      "request_type":"Doc Del",
+      "delivery_type":"Scan",
+      "source":"Illiad",
+      "title":"Popular music",
+      "author":"",
+      "description":"7 03 1988",
+      "pages":"-285",
+      "journal_title":"",
+      "article_title":"Country Music Video",
+      "article_author":"Mark Fenster",
+      "barcode":"",
+      "isbn_issn":"",
+      "bib_number":"",
+      "adm_number":"",
+      "ill_system_id":"",
+      "item_sequence":"",
+      "call_number":"",
+      "send_to":"",
+      "rush":"Regular"
+    },
+    {
+      "transaction":"illiad-851321",
+      "request_date_time":"2015-05-05T08:46:00Z",
+      "request_type":"Doc Del",
+      "delivery_type":"Scan",
+      "source":"Illiad",
+      "title":"Popular music",
+      "author":"",
+      "description":"7 03 1988",
+      "pages":"-285",
+      "journal_title":"",
+      "article_title":"Country Music Video",
+      "article_author":"Mark Fenster",
+      "barcode":"",
+      "isbn_issn":"",
+      "bib_number":"",
+      "adm_number":"",
+      "ill_system_id":"",
+      "item_sequence":"",
+      "call_number":"",
+      "send_to":"",
+      "rush":"Regular"
+    }
+  ]
+}

--- a/spec/fixtures/api/item_metadata.json
+++ b/spec/fixtures/api/item_metadata.json
@@ -5,11 +5,11 @@
   "sequence_number":"00010",
   "admin_document_number":"000841979",
   "call_number":"Q 172.5 .C45 U25 1990",
-  "description":"",
+  "description":"Description",
   "title":"The ubiquity of chaos / edited by Saul Krasner.",
-  "author":"",
+  "author":"Author",
   "publication":"Washington, DC : American Association for the Advancement of Science, 1990.",
-  "edition":"",
-  "isbn_issn":"0871683504 : $24.95",
-  "condition":null
+  "edition":"Edition",
+  "isbn_issn":"0871683504",
+  "condition":["Condition"]
 }

--- a/spec/fixtures/api/item_metadata.json
+++ b/spec/fixtures/api/item_metadata.json
@@ -1,0 +1,15 @@
+{
+  "item_id":"00084197900010",
+  "barcode":"00000007819006",
+  "bib_id":"000841979",
+  "sequence_number":"00010",
+  "admin_document_number":"000841979",
+  "call_number":"Q 172.5 .C45 U25 1990",
+  "description":"",
+  "title":"The ubiquity of chaos / edited by Saul Krasner.",
+  "author":"",
+  "publication":"Washington, DC : American Association for the Advancement of Science, 1990.",
+  "edition":"",
+  "isbn_issn":"0871683504 : $24.95",
+  "condition":null
+}

--- a/spec/fixtures/api/scan_send.json
+++ b/spec/fixtures/api/scan_send.json
@@ -1,0 +1,4 @@
+{
+  "status": "OK",
+  "message": "Item stocked"
+}

--- a/spec/fixtures/api/scan_send.json
+++ b/spec/fixtures/api/scan_send.json
@@ -1,4 +1,4 @@
 {
   "status": "OK",
-  "message": "Item stocked"
+  "message": "Item status updated"
 }

--- a/spec/fixtures/api/stock_item.json
+++ b/spec/fixtures/api/stock_item.json
@@ -1,0 +1,4 @@
+{
+  "status": "OK",
+  "message": "Item stocked"
+}

--- a/spec/models/api_response_spec.rb
+++ b/spec/models/api_response_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe ApiResponse do
+  let(:status_code) { 200 }
+  let(:data) do
+    {
+      title: "title",
+      author: "author",
+      chron: "chron",
+      bib_number: "bib_number",
+      isbn_issn: "isbn",
+      conditions: "conditions",
+      call_number: "call_number",
+    }
+  end
+
+  subject { described_class.new(status_code: status_code, body: data) }
+
+  context "success" do
+    let(:status_code) { 200 }
+
+    it "returns true for success?" do
+      expect(subject.success?).to eq(true)
+    end
+
+    it "returns false for error?" do
+      expect(subject.error?).to eq(false)
+    end
+  end
+
+  shared_examples "an error response" do
+    it "returns false for success?" do
+      expect(subject.success?).to eq(false)
+    end
+
+    it "returns true for error?" do
+      expect(subject.error?).to eq(true)
+    end
+  end
+
+  context "internal error" do
+    let(:status_code) { 500 }
+
+    it_behaves_like "an error response"
+  end
+
+  context "timeout" do
+    let(:status_code) { 599 }
+
+    it_behaves_like "an error response"
+
+    it "returns true for timeout?" do
+      expect(subject.timeout?).to eq(true)
+    end
+  end
+
+  context "unauthorized" do
+    let(:status_code) { 401 }
+
+    it_behaves_like "an error response"
+
+    it "returns true for unauthorized?" do
+      expect(subject.unauthorized?).to eq(true)
+    end
+  end
+
+  context "not_found" do
+    let(:status_code) { 404 }
+
+    it_behaves_like "an error response"
+
+    it "returns true for not_found?" do
+      expect(subject.not_found?).to eq(true)
+    end
+  end
+end

--- a/spec/models/api_response_spec.rb
+++ b/spec/models/api_response_spec.rb
@@ -81,7 +81,15 @@ RSpec.describe ApiResponse do
     end
   end
 
-  context "data with string keys" do
+  context "array body" do
+    let(:data) { [1, 2, 3] }
+
+    it "has the array as the body" do
+      expect(subject.body).to eq([1, 2, 3])
+    end
+  end
+
+  context "body with string keys" do
     let(:data) do
       {
         "title" => "string title",

--- a/spec/models/api_response_spec.rb
+++ b/spec/models/api_response_spec.rb
@@ -73,4 +73,24 @@ RSpec.describe ApiResponse do
       expect(subject.not_found?).to eq(true)
     end
   end
+
+  context "body" do
+    it "can be accessed with string or symbol keys" do
+      expect(subject.body[:title]).to eq("title")
+      expect(subject.body["title"]).to eq("title")
+    end
+  end
+
+  context "data with string keys" do
+    let(:data) do
+      {
+        "title" => "string title",
+        "author" => "string authors",
+      }
+    end
+
+    it "can be accessed with symbols" do
+      expect(subject.body[:title]).to eq("string title")
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,5 +51,5 @@ RSpec.configure do |config|
   # For Devise testing
   config.include Devise::TestHelpers, type: :controller
 
-  config.include ApiUrlHelper
+  config.include ApiHelper
 end

--- a/spec/services/api_get_item_metadata_spec.rb
+++ b/spec/services/api_get_item_metadata_spec.rb
@@ -1,5 +1,30 @@
 require "rails_helper"
 
 RSpec.describe ApiGetItemMetadata do
-  it "needs specs"
+  let(:barcode) { "00000007819006" }
+
+  context "self" do
+    subject { described_class }
+
+    describe "#call" do
+      subject { described_class.call(barcode) }
+
+      it "retrieves data" do
+        stub_api_item_metadata(barcode: barcode)
+        expect(subject).to be_a_kind_of(ApiResponse)
+        expect(subject.success?).to eq(true)
+        expect(subject.body).to be_a_kind_of(Hash)
+        expect(subject.body[:title]).to eq("The ubiquity of chaos / edited by Saul Krasner.")
+      end
+
+      it "does not raise an exception on API failure" do
+        stub_api_item_metadata(barcode: barcode, status_code: 500, body: {}.to_json)
+        # stub_api_active_requests(status_code: 500, body: {}.to_json)
+        expect(subject).to be_a_kind_of(ApiResponse)
+        expect(subject.error?).to eq(true)
+        expect(subject.body).to be_a_kind_of(Hash)
+        expect(subject.body[:title]).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/api_get_item_metadata_spec.rb
+++ b/spec/services/api_get_item_metadata_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ApiGetItemMetadata do
+  it "needs specs"
+end

--- a/spec/services/api_get_request_list_spec.rb
+++ b/spec/services/api_get_request_list_spec.rb
@@ -11,9 +11,17 @@ RSpec.describe ApiGetRequestList do
       it "retrieves data" do
         stub_api_active_requests
         expect(subject).to be_a_kind_of(ApiResponse)
+        expect(subject.success?).to eq(true)
         expect(subject.body).to be_a_kind_of(Array)
         expect(subject.body.count).to eq(2)
-        expect(subject.body.first).to eq(2)
+      end
+
+      it "does not raise an exception on API failure" do
+        stub_api_active_requests(status_code: 500, body: {}.to_json)
+        expect(subject).to be_a_kind_of(ApiResponse)
+        expect(subject.error?).to eq(true)
+        expect(subject.body).to be_a_kind_of(Array)
+        expect(subject.body.count).to eq(0)
       end
     end
   end

--- a/spec/services/api_get_request_list_spec.rb
+++ b/spec/services/api_get_request_list_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe ApiGetRequestList do
+  let(:user_id) { 1 }
+  context "self" do
+    subject { described_class }
+
+    describe "#call" do
+      subject { described_class.call(user_id) }
+
+      it "retrieves data" do
+        stub_api_active_requests
+        expect(subject).to be_a_kind_of(ApiResponse)
+        expect(subject.body).to be_a_kind_of(Array)
+        expect(subject.body.count).to eq(2)
+        expect(subject.body.first).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/api_handler_spec.rb
+++ b/spec/services/api_handler_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe ApiHandler do
+  let(:raw_response) do
+    ""
+  end
+
+  let(:auth_token) { Rails.application.secrets.api_token }
+  let(:method) { "GET" }
+  let(:path) { "1.0/test" }
+  let(:params) { { test: "test" } }
+  let(:connection) { instance_double(ExternalRestConnection) }
+
+  subject { described_class.new(method, path, params) }
+
+  before do
+    allow(ExternalRestConnection).to receive(:new).and_return(connection)
+  end
+
+  context "self" do
+    subject { described_class }
+
+    describe "#call" do
+      it "instantiates a new record and calls transact!" do
+        expect(described_class).to receive(:new).with("GET", path, params).and_call_original
+        expect_any_instance_of(described_class).to receive(:transact!).and_return("response")
+        expect(subject.call("GET", path, params)).to eq("response")
+      end
+    end
+
+    describe "#get" do
+      it "calls #call with GET" do
+        expect(described_class).to receive(:call).with("GET", path, params).and_return("response")
+        expect(subject.get(path, params)).to eq("response")
+      end
+    end
+
+    describe "#post" do
+      it "calls #call with POST" do
+        expect(described_class).to receive(:call).with("POST", path, params).and_return("response")
+        expect(subject.post(path, params)).to eq("response")
+      end
+    end
+  end
+
+  context "GET" do
+    it "calls #get on the connection and includes the params" do
+      expect(connection).to receive(:get).with("#{path}?auth_token=#{auth_token}&#{params.to_param}")
+      subject.transact!
+    end
+  end
+
+  context "POST" do
+    let(:method) { "POST" }
+
+    it "calls #post on the connection" do
+      expect(connection).to receive(:post).with("#{path}?auth_token=#{auth_token}", params)
+      subject.transact!
+    end
+  end
+
+  context "PUT" do
+    let(:method) { "PUT" }
+
+    it "raises an error" do
+      expect { subject.transact! }.to raise_error(described_class::HTTPMethodNotImplemented)
+    end
+  end
+end

--- a/spec/services/api_post_deliver_item_spec.rb
+++ b/spec/services/api_post_deliver_item_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ApiPostDeliverItem do
         stub_api_scan_send(match: match)
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.success?).to eq(true)
-        expect(subject.body).to eq("status"=>"OK", "message"=>"Item status updated")
+        expect(subject.body).to eq("status" => "OK", "message" => "Item status updated")
       end
 
       it "does not raise an exception on API failure" do

--- a/spec/services/api_post_deliver_item_spec.rb
+++ b/spec/services/api_post_deliver_item_spec.rb
@@ -1,24 +1,26 @@
 require "rails_helper"
 
-RSpec.describe ApiGetItemMetadata do
-  let(:barcode) { "00000007819006" }
+RSpec.describe ApiPostDeliverItem do
+  let(:match) { FactoryGirl.create(:match, item: item) }
+  let(:tray) { FactoryGirl.create(:tray) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:item) { FactoryGirl.create(:item, tray: tray) }
 
   context "self" do
     subject { described_class }
 
     describe "#call" do
-      subject { described_class.call(barcode) }
+      subject { described_class.call(match.id, user) }
 
       it "retrieves data" do
-        stub_api_item_metadata(barcode: barcode)
+        stub_api_scan_send(match: match)
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.success?).to eq(true)
-        expect(subject.body).to be_a_kind_of(Hash)
-        expect(subject.body[:title]).to eq("The ubiquity of chaos / edited by Saul Krasner.")
+        expect(subject.body).to eq("status"=>"OK", "message"=>"Item stocked")
       end
 
       it "does not raise an exception on API failure" do
-        stub_api_item_metadata(barcode: barcode, status_code: 500, body: {}.to_json)
+        stub_api_scan_send(match: match, status_code: 500, body: {}.to_json)
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.error?).to eq(true)
         expect(subject.body).to be_a_kind_of(Hash)

--- a/spec/services/api_post_stock_item_spec.rb
+++ b/spec/services/api_post_stock_item_spec.rb
@@ -1,30 +1,27 @@
 require "rails_helper"
 
-RSpec.describe ApiPostDeliverItem do
-  let(:match) { FactoryGirl.create(:match, item: item) }
+RSpec.describe ApiPostStockItem do
   let(:tray) { FactoryGirl.create(:tray) }
-  let(:user) { FactoryGirl.create(:user) }
   let(:item) { FactoryGirl.create(:item, tray: tray) }
 
   context "self" do
     subject { described_class }
 
     describe "#call" do
-      subject { described_class.call(match.id, user) }
+      subject { described_class.call(item.id) }
 
       it "retrieves data" do
-        stub_api_scan_send(match: match)
+        stub_api_stock_item(item: item)
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.success?).to eq(true)
-        expect(subject.body).to eq("status"=>"OK", "message"=>"Item status updated")
+        expect(subject.body).to eq("status"=>"OK", "message"=>"Item stocked")
       end
 
       it "does not raise an exception on API failure" do
-        stub_api_scan_send(match: match, status_code: 500, body: {}.to_json)
+        stub_api_stock_item(item: item, status_code: 500, body: {}.to_json)
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.error?).to eq(true)
-        expect(subject.body).to be_a_kind_of(Hash)
-        expect(subject.body[:title]).to be_nil
+        expect(subject.body).to eq({})
       end
     end
   end

--- a/spec/services/api_post_stock_item_spec.rb
+++ b/spec/services/api_post_stock_item_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApiPostStockItem do
         stub_api_stock_item(item: item)
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.success?).to eq(true)
-        expect(subject.body).to eq("status"=>"OK", "message"=>"Item stocked")
+        expect(subject.body).to eq("status" => "OK", "message" => "Item stocked")
       end
 
       it "does not raise an exception on API failure" do

--- a/spec/services/get_item_from_barcode_spec.rb
+++ b/spec/services/get_item_from_barcode_spec.rb
@@ -3,26 +3,12 @@ require "rails_helper"
 RSpec.describe GetItemFromBarcode do
   subject { described_class.call(user.id, barcode) }
 
-  let(:api_response_status) { 200 }
-  let(:item) { instance_double(Item, attributes: item_attr) }
   let(:user) { instance_double(User, username: "bob", id: 1) }
-  let(:barcode) { 123456789 }
-  let!(:data) { { "status" => api_response_status, "results" => item_attr } }
-  let(:item_attr) do
-    {
-      "title" => "Symphony no. 2, op. 16 : The four temperaments / Carl Nielsen.",
-      "author" => "Nielsen, Carl, 1865-1931.",
-      "chron" => "",
-      "bib_number" => "001883956",
-      "isbn_issn" => "0486418979",
-      "conditions" => nil,
-      "call_number" =>" M 1001 .N5 S2 2002"
-    }
-  end
+  let(:barcode) { "123456789" }
 
   before(:each) do
     allow(User).to receive(:find).and_return(user)
-    allow(ApiGetItemMetadata).to receive(:call).with(barcode).and_return(data)
+    allow(SyncItemMetadata).to receive(:call)
   end
 
   context "invalid barcode" do
@@ -33,74 +19,28 @@ RSpec.describe GetItemFromBarcode do
   end
 
   context "given a valid item" do
-    it "updates the item with data from the api" do
-      expect(subject.attributes).to include(item.attributes)
+    it "creates an item" do
+      expect { subject }.to change { Item.count }.by(1)
     end
 
     it "logs the activity" do
       expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
-      expect(LogActivity).to receive(:call).with(anything, "UpdatedByAPI", anything, anything, anything).ordered
-      subject
-    end
-  end
-
-  context "given an invalid item" do
-    let(:api_response_status) { 404 }
-
-    it "logs an issue" do
-      expect(AddIssue).to receive(:call).with(user.id, barcode, "Item not found.")
       subject
     end
 
-    it "destroys the item" do
-      expect_any_instance_of(Item).to receive(:destroy!)
+    it "calls SyncItemMetadata" do
+      expect(SyncItemMetadata).to receive(:call).with(item: kind_of(Item), user_id: user.id)
       subject
     end
 
-    it "logs the activity" do
-      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
-      expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
-      subject
-    end
-  end
-
-  context "unauthorized api request" do
-    let(:api_response_status) { 401 }
-
-    it "logs an issue" do
-      expect(AddIssue).to receive(:call).with(user.id, barcode, "Unauthorized - Check API Key.")
-      subject
+    it "returns the item on successful sync" do
+      expect(SyncItemMetadata).to receive(:call).and_return(true)
+      expect(subject).to be_kind_of(Item)
     end
 
-    it "destroys the item" do
-      expect_any_instance_of(Item).to receive(:destroy!)
-      subject
-    end
-
-    it "logs the activity" do
-      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
-      expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
-      subject
-    end
-  end
-
-  context "api time out" do
-    let(:api_response_status) { 599 }
-
-    it "logs an issue" do
-      expect(AddIssue).to receive(:call).with(user.id, barcode, "API Timeout.")
-      subject
-    end
-
-    it "destroys the item" do
-      expect_any_instance_of(Item).to receive(:destroy!)
-      subject
-    end
-
-    it "logs the activity" do
-      expect(LogActivity).to receive(:call).with(anything, "Created", anything, anything, anything).ordered
-      expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
-      subject
+    it "returns nil on failed sync" do
+      expect(SyncItemMetadata).to receive(:call).and_return(false)
+      expect(subject).to be_nil
     end
   end
 end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe SyncItemMetadata do
+  it "needs specs"
+end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -1,5 +1,34 @@
 require "rails_helper"
 
 RSpec.describe SyncItemMetadata do
-  it "needs specs"
+  let(:barcode) { "00000007819006" }
+  let(:item) { FactoryGirl.create(:item, barcode: barcode) }
+  let(:user_id) { 1 }
+
+  context "self" do
+    subject { described_class }
+
+    describe "#call" do
+      subject { described_class.call(item: item, user_id: user_id) }
+
+      it "updates the item metadata" do
+        stub_api_item_metadata(barcode: barcode)
+        expect(subject).to eq(true)
+        expect(item.title).to eq("The ubiquity of chaos / edited by Saul Krasner.")
+        expect(item.author).to eq("Author")
+        expect(item.chron).to eq("Description")
+        expect(item.bib_number).to eq("000841979")
+        expect(item.isbn_issn).to eq("0871683504")
+        expect(item.conditions).to eq(["Condition"])
+        expect(item.call_number).to eq("Q 172.5 .C45 U25 1990")
+      end
+
+      it "returns false when an error is encountered, adds an issue and destroys the item" do
+        stub_api_item_metadata(barcode: barcode, status_code: 500, body: {}.to_json)
+        expect(AddIssue).to receive(:call).and_call_original
+        expect(subject).to eq(false)
+        expect(Item.exists?(item.id)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe SyncItemMetadata do
   let(:barcode) { "00000007819006" }
   let(:item) { FactoryGirl.create(:item, barcode: barcode) }
-  let(:user_id) { FactoryGirl.create(:user).id }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:user_id) { user.id }
 
   context "self" do
     subject { described_class }
@@ -11,23 +12,79 @@ RSpec.describe SyncItemMetadata do
     describe "#call" do
       subject { described_class.call(item: item, user_id: user_id) }
 
-      it "updates the item metadata" do
-        stub_api_item_metadata(barcode: barcode)
-        expect(subject).to eq(true)
-        expect(item.title).to eq("The ubiquity of chaos / edited by Saul Krasner.")
-        expect(item.author).to eq("Author")
-        expect(item.chron).to eq("Description")
-        expect(item.bib_number).to eq("000841979")
-        expect(item.isbn_issn).to eq("0871683504")
-        expect(item.conditions).to eq(["Condition"])
-        expect(item.call_number).to eq("Q 172.5 .C45 U25 1990")
+      context "success" do
+        before do
+          stub_api_item_metadata(barcode: barcode)
+        end
+
+        it "updates the item metadata" do
+          expect(subject).to eq(true)
+          expect(item.title).to eq("The ubiquity of chaos / edited by Saul Krasner.")
+          expect(item.author).to eq("Author")
+          expect(item.chron).to eq("Description")
+          expect(item.bib_number).to eq("000841979")
+          expect(item.isbn_issn).to eq("0871683504")
+          expect(item.conditions).to eq(["Condition"])
+          expect(item.call_number).to eq("Q 172.5 .C45 U25 1990")
+        end
+
+        it "logs the activity" do
+          expect(LogActivity).to receive(:call).with(anything, "UpdatedByAPI", anything, anything, anything).ordered
+          expect(subject).to eq(true)
+        end
       end
 
-      it "returns false when an error is encountered, adds an issue and destroys the item" do
-        stub_api_item_metadata(barcode: barcode, status_code: 500, body: {}.to_json)
-        expect(AddIssue).to receive(:call).and_call_original
-        expect(subject).to eq(false)
-        expect(Item.exists?(item.id)).to eq(false)
+      context "error response" do
+        let(:status_code) { 500 }
+
+        before do
+          stub_api_item_metadata(barcode: barcode, status_code: 500, body: {}.to_json)
+        end
+
+        shared_examples "an error response" do
+          it "returns false" do
+            expect(subject).to eq(false)
+          end
+
+          it "adds an issue" do
+            expect(AddIssue).to receive(:call).with(user.id, barcode, anything).and_call_original
+            subject
+          end
+
+          it "destroys the item" do
+            expect(item).to receive(:destroy!)
+            subject
+          end
+
+          it "logs the activity" do
+            expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
+            subject
+          end
+        end
+
+        context "500 error" do
+          let(:status_code) { 500 }
+
+          it_behaves_like "an error response"
+        end
+
+        context "not found error" do
+          let(:status_code) { 404 }
+
+          it_behaves_like "an error response"
+        end
+
+        context "timeout error" do
+          let(:status_code) { 599 }
+
+          it_behaves_like "an error response"
+        end
+
+        context "unauthorized error" do
+          let(:status_code) { 401 }
+
+          it_behaves_like "an error response"
+        end
       end
     end
   end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SyncItemMetadata do
   let(:barcode) { "00000007819006" }
   let(:item) { FactoryGirl.create(:item, barcode: barcode) }
-  let(:user_id) { 1 }
+  let(:user_id) { FactoryGirl.create(:user).id }
 
   context "self" do
     subject { described_class }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,6 +79,22 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.before(:suite) do
+    # Preload the fields for ActiveRecord objects to allow use of instance_double
+    [
+      User
+    ].each do |database_model|
+      instance = database_model.new
+      # The first attribute is id, which does not cause the methods to be built on the class
+      field = instance.attributes.keys[1]
+      # Trigger method missing on the instance which dynamically adds the methods to the class
+      instance.send(field)
+
+      # Reload all factories
+      FactoryGirl.reload
+    end
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,12 @@ require 'webmock/rspec'
 require 'capybara/rspec'
 
 RSpec.configure do |config|
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -20,6 +20,10 @@ module ApiHelper
     api_url("1.0/resources/items/send")
   end
 
+  def api_scan_url
+    api_url("1.0/resources/items/send")
+  end
+
   def api_item_metadata_url(barcode)
     api_url("1.0/resources/items/record", barcode: barcode)
   end
@@ -30,6 +34,32 @@ module ApiHelper
 
   def api_requests_url
     api_url("1.0/resources/items/active_requests")
+  end
+
+  def stub_api_scan_send(match:, status_code: 200, body: nil)
+    body ||= api_fixture_data("scan_send.json")
+    if match.request.del_type == "scan"
+      url = api_scan_url
+    else
+      url = api_send_url
+    end
+    stub_request(:post, url).
+      with(body: api_scan_send_params(match),
+           headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: status_code, body: body, headers: {})
+  end
+
+  def api_scan_send_params(match)
+    delivery_type = (match.request.del_type == "scan") ? "scan" : "send"
+    {
+      item_id: match.item.id.to_s,
+      barcode: match.item.barcode,
+      tray_code: match.item.tray.barcode,
+      source: match.request.source,
+      transaction_num: match.request.trans.to_s,
+      request_type: match.request.req_type,
+      delivery_type: delivery_type
+    }
   end
 
   def stub_api_active_requests(status_code: 200, body: nil)

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -16,12 +16,20 @@ module ApiHelper
     api_url("1.0/resources/items/stock")
   end
 
+  def api_scan_send_url(match)
+    if match.request.del_type == "scan"
+      api_scan_url
+    else
+      api_send_url
+    end
+  end
+
   def api_send_url
     api_url("1.0/resources/items/send")
   end
 
   def api_scan_url
-    api_url("1.0/resources/items/send")
+    api_url("1.0/resources/items/scan")
   end
 
   def api_item_metadata_url(barcode)
@@ -54,19 +62,21 @@ module ApiHelper
 
   def stub_api_scan_send(match:, status_code: 200, body: nil)
     body ||= api_fixture_data("scan_send.json")
-    if match.request.del_type == "scan"
-      url = api_scan_url
-    else
-      url = api_send_url
-    end
-    stub_request(:post, url).
+    stub_request(:post, api_scan_send_url(match)).
       with(body: api_scan_send_params(match),
            headers: { "User-Agent" => "Faraday v0.9.1" }).
       to_return(status: status_code, body: body, headers: {})
   end
 
+  def api_scan_send_delivery_type(match)
+    if match.request.del_type == "scan"
+      "scan"
+    else
+      "send"
+    end
+  end
+
   def api_scan_send_params(match)
-    delivery_type = (match.request.del_type == "scan") ? "scan" : "send"
     {
       item_id: match.item.id.to_s,
       barcode: match.item.barcode,
@@ -74,7 +84,7 @@ module ApiHelper
       source: match.request.source,
       transaction_num: match.request.trans.to_s,
       request_type: match.request.req_type,
-      delivery_type: delivery_type
+      delivery_type: api_scan_send_delivery_type(match)
     }
   end
 

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -20,8 +20,12 @@ module ApiHelper
     api_url("1.0/resources/items/send")
   end
 
+  def api_item_metadata_url(barcode)
+    api_url("1.0/resources/items/record", barcode: barcode)
+  end
+
   def api_item_url(item)
-    api_url("1.0/resources/items/record", barcode: item.barcode)
+    api_item_metadata_url(item.barcode)
   end
 
   def api_requests_url
@@ -33,6 +37,20 @@ module ApiHelper
     stub_request(:get, api_requests_url).
       with(headers: { "User-Agent" => "Faraday v0.9.1" }).
       to_return(status: status_code, body: body, headers: {})
+  end
+
+  def stub_api_item_metadata(barcode:, status_code: 200, body: nil)
+    body ||= api_item_metadata_json(barcode)
+    stub_request(:get, api_item_metadata_url(barcode)).
+      with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: status_code, body: body, headers: {})
+  end
+
+  def api_item_metadata_json(barcode)
+    data = api_fixture_data("item_metadata.json")
+    hash = JSON.parse(data)
+    hash["barcode"] = barcode
+    hash.to_json
   end
 
   def api_fixture_data(filename)

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,4 +1,4 @@
-module ApiUrlHelper
+module ApiHelper
   def api_url(path, params_hash = {})
     base_url = Rails.application.secrets.api_server || "http:/"
     auth_token = Rails.application.secrets.api_token
@@ -22,5 +22,20 @@ module ApiUrlHelper
 
   def api_item_url(item)
     api_url("1.0/resources/items/record", barcode: item.barcode)
+  end
+
+  def api_requests_url
+    api_url("1.0/resources/items/active_requests")
+  end
+
+  def stub_api_active_requests(status_code: 200, body: nil)
+    body ||= api_fixture_data("active_requests.json")
+    stub_request(:get, api_requests_url).
+      with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: 200, body: body, headers: {})
+  end
+
+  def api_fixture_data(filename)
+    File.read(Rails.root.join("spec/fixtures/api", filename))
   end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,19 +1,15 @@
 module ApiHelper
-  def api_url(path, params_hash = {})
-    base_url = Rails.application.secrets.api_server || "http:/"
-    auth_token = Rails.application.secrets.api_token
-    unless path =~ /^\//
-      path = "/#{path}"
-    end
-    params = { auth_token: auth_token }.to_param
+  def api_url(action, params_hash = {})
+    base_url = ApiHandler.base_url || "http:/"
+    path = ApiHandler.path(action)
     if params_hash.present?
-      params += "&#{params_hash.to_param}"
+      path += "&#{params_hash.to_param}"
     end
-    Addressable::URI.parse "#{base_url}#{path}?#{params}"
+    Addressable::URI.parse "#{base_url}#{path}"
   end
 
   def api_stock_url
-    api_url("1.0/resources/items/stock")
+    api_url(:stock)
   end
 
   def api_scan_send_url(match)
@@ -25,15 +21,15 @@ module ApiHelper
   end
 
   def api_send_url
-    api_url("1.0/resources/items/send")
+    api_url(:send)
   end
 
   def api_scan_url
-    api_url("1.0/resources/items/scan")
+    api_url(:scan)
   end
 
   def api_item_metadata_url(barcode)
-    api_url("1.0/resources/items/record", barcode: barcode)
+    api_url(:record, barcode: barcode)
   end
 
   def api_item_url(item)
@@ -41,7 +37,7 @@ module ApiHelper
   end
 
   def api_requests_url
-    api_url("1.0/resources/items/active_requests")
+    api_url(:active_requests)
   end
 
   def stub_api_stock_item(item:, status_code: 200, body: nil)

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -32,7 +32,7 @@ module ApiHelper
     body ||= api_fixture_data("active_requests.json")
     stub_request(:get, api_requests_url).
       with(headers: { "User-Agent" => "Faraday v0.9.1" }).
-      to_return(status: 200, body: body, headers: {})
+      to_return(status: status_code, body: body, headers: {})
   end
 
   def api_fixture_data(filename)

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -36,6 +36,22 @@ module ApiHelper
     api_url("1.0/resources/items/active_requests")
   end
 
+  def stub_api_stock_item(item:, status_code: 200, body: nil)
+    body ||= api_fixture_data("stock_item.json")
+    stub_request(:post, api_stock_url).
+      with(body: api_stock_item_params(item),
+           headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: status_code, body: body, headers: {})
+  end
+
+  def api_stock_item_params(item)
+    {
+      item_id: item.id.to_s,
+      barcode: item.barcode,
+      tray_code: item.tray.barcode
+    }
+  end
+
   def stub_api_scan_send(match:, status_code: 200, body: nil)
     body ||= api_fixture_data("scan_send.json")
     if match.request.del_type == "scan"


### PR DESCRIPTION
This is some groundwork changes to the API calls that are needed before they can easily be moved to the background.  I didn't change any business logic as part of this pull request.

All API calls now return an ApiResponse which contains the status and the body of the response.  This response object can answer simple questions like whether the response was a success (200) or error.
The API handler will catch timeout errors and still return an ApiResponse.  Previously each API service was trapping their own timeout errors.
Disabled network request caching in the development and test environments.
Moved item metadata synchronization into its own service class.
Added specs for all API requests.
Updated the overall test suite order to be random, to help expose any test order dependencies.