### PR TITLE
Aims 212 item metadata status

### DIFF
--- a/app/jobs/sync_item_metadata_job.rb
+++ b/app/jobs/sync_item_metadata_job.rb
@@ -1,0 +1,7 @@
+class SyncItemMetadataJob < ActiveJob::Base
+  queue_as ItemMetadataWorker::QUEUE_NAME
+
+  def perform(item:, user_id:)
+    SyncItemMetadata.call(item: item, user_id: user_id)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,12 +12,20 @@ class Item < ActiveRecord::Base
     "UNBOUND",
     "OTHER"]
 
+  METADATA_STATUSES = [
+    "pending",
+    "complete",
+    "not_found",
+    "error",
+  ]
+
   enum status: { stocked: 0, unstocked: 1, shipped: 2}
 
   validates_presence_of :barcode
   validates_presence_of :thickness, on: :update  # Items are going to be programmatically created, humans will be required to enter thickness.
   validates_numericality_of :thickness, on: :update, only_integer: true, greater_than_or_equal_to: 0
   validates :barcode, uniqueness: true
+  validates :metadata_status, inclusion: METADATA_STATUSES
   validate :has_correct_prefix
 
   belongs_to :tray

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -11,6 +11,16 @@ class SyncItemMetadata
   end
 
   def sync
+    if sync_required?
+      perform_sync
+    else
+      true
+    end
+  end
+
+  private
+
+  def perform_sync
     response = ApiGetItemMetadata.call(barcode)
     if response.success?
       save_metadata(response.body)
@@ -21,7 +31,9 @@ class SyncItemMetadata
     end
   end
 
-  private
+  def sync_required?
+    item.metadata_status != "complete"
+  end
 
   def user
     @user ||= User.find(user_id)

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -1,11 +1,11 @@
 class SyncItemMetadata
   attr_reader :item, :user_id
 
-  def self.call(item: item, user_id: user_id)
+  def self.call(item:, user_id:)
     new(item: item, user_id: user_id).sync
   end
 
-  def initialize(item: item, user_id: user_id)
+  def initialize(item:, user_id:)
     @item = item
     @user_id = user_id
   end

--- a/app/workers/item_metadata_worker.rb
+++ b/app/workers/item_metadata_worker.rb
@@ -1,7 +1,8 @@
 class ItemMetadataWorker < RetryWorker
   WORKERS = 4
+  QUEUE_NAME = "annex_item_metadata"
 
-  from_queue "annex_item_metadata",
+  from_queue QUEUE_NAME,
              threads: 1,
              timeout_job_after: 60,
              prefetch: 1

--- a/db/migrate/20150625190556_add_item_metadata_status.rb
+++ b/db/migrate/20150625190556_add_item_metadata_status.rb
@@ -1,0 +1,6 @@
+class AddItemMetadataStatus < ActiveRecord::Migration
+  def change
+    add_column :items, :metadata_updated_at, :datetime
+    add_column :items, :metadata_status, :string, limit: 20, default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150623185029) do
+ActiveRecord::Schema.define(version: 20150625190556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,22 +72,24 @@ ActiveRecord::Schema.define(version: 20150623185029) do
   add_index "issues", ["user_id"], name: "index_issues_on_user_id", using: :btree
 
   create_table "items", force: true do |t|
-    t.string   "barcode",                     null: false
+    t.string   "barcode",                                            null: false
     t.string   "title"
     t.string   "author"
     t.string   "chron"
     t.integer  "thickness"
     t.integer  "tray_id"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.string   "bib_number"
     t.string   "isbn_issn"
-    t.text     "conditions",     default: [],              array: true
+    t.text     "conditions",                     default: [],                     array: true
     t.string   "call_number"
     t.date     "initial_ingest"
     t.date     "last_ingest"
     t.integer  "bin_id"
-    t.integer  "status",         default: 0,  null: false
+    t.integer  "status",                         default: 0,         null: false
+    t.datetime "metadata_updated_at"
+    t.string   "metadata_status",     limit: 20, default: "pending"
   end
 
   add_index "items", ["barcode"], name: "index_items_on_barcode", unique: true, using: :btree

--- a/spec/jobs/sync_item_metadata_job_spec.rb
+++ b/spec/jobs/sync_item_metadata_job_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe SyncItemMetadataJob, type: :job do
+  let(:item) { instance_double(Item) }
+  let(:user_id) { 1 }
+
+  subject { described_class }
+
+  describe "#perform" do
+    it "calls SyncItemMetadata with set values" do
+      expect(SyncItemMetadata).to receive(:call).with(item: item, user_id: user_id)
+      subject.perform_now(item: item, user_id: user_id)
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,31 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe Item, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe Item, type: :model do
+  subject { described_class.new }
+
+  describe "#metadata_status" do
+    it "defaults to pending" do
+      expect(subject.metadata_status).to eq("pending")
+    end
+
+    described_class::METADATA_STATUSES.each do |status|
+      it "accepts the value #{status}" do
+        subject.metadata_status = status
+        subject.valid?
+        expect(subject.errors[:metadata_status].size).to eq(0)
+      end
+    end
+
+    it "does not accept other values" do
+      subject.metadata_status = "test"
+      subject.valid?
+      expect(subject.errors[:metadata_status].size).to eq(1)
+    end
+
+    it "does not accept nil" do
+      subject.metadata_status = nil
+      subject.valid?
+      expect(subject.errors[:metadata_status].size).to eq(1)
+    end
+  end
 end

--- a/spec/services/get_item_from_barcode_spec.rb
+++ b/spec/services/get_item_from_barcode_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GetItemFromBarcode do
     end
   end
 
-  context "given a valid item" do
+  context "new item" do
     it "creates an item" do
       expect { subject }.to change { Item.count }.by(1)
     end
@@ -33,14 +33,49 @@ RSpec.describe GetItemFromBarcode do
       subject
     end
 
-    it "returns the item on successful sync" do
-      expect(SyncItemMetadata).to receive(:call).and_return(true)
+    it "returns the item" do
       expect(subject).to be_kind_of(Item)
     end
+  end
 
-    it "returns nil on failed sync" do
-      expect(SyncItemMetadata).to receive(:call).and_return(false)
-      expect(subject).to be_nil
+  context "existing item" do
+    let(:metadata_status) { "pending" }
+    let(:item) { instance_double(Item, metadata_status: metadata_status) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:item).and_return(item)
+    end
+
+    context "not_found status" do
+      let(:metadata_status) { "not_found" }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "error status" do
+      let(:metadata_status) { "error" }
+
+      it "returns the item" do
+        expect(subject).to eq(item)
+      end
+    end
+
+    context "complete status" do
+      let(:metadata_status) { "complete" }
+
+      it "returns the item" do
+        expect(subject).to eq(item)
+      end
+    end
+
+    context "pending status" do
+      let(:metadata_status) { "pending" }
+
+      it "returns the item" do
+        expect(subject).to eq(item)
+      end
     end
   end
 end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe SyncItemMetadata do
     describe "#call" do
       subject { described_class.call(item: item, user_id: user_id) }
 
+      shared_examples "a metadata status update" do |expected_status|
+        it "sets the item metadata_status to #{expected_status}" do
+          subject
+          expect(item.metadata_status).to eq(expected_status)
+        end
+
+        it "updates the metadata_updated_at" do
+          expect(item.metadata_updated_at).to be_nil
+          subject
+          expect(item.metadata_updated_at).to be_present
+          expect(Time.now - item.metadata_updated_at).to be < 1
+        end
+      end
+
       context "success" do
         before do
           stub_api_item_metadata(barcode: barcode)
@@ -35,30 +49,13 @@ RSpec.describe SyncItemMetadata do
       end
 
       context "error response" do
-        let(:status_code) { 500 }
-
         before do
-          stub_api_item_metadata(barcode: barcode, status_code: 500, body: {}.to_json)
+          stub_api_item_metadata(barcode: barcode, status_code: status_code, body: {}.to_json)
         end
 
         shared_examples "an error response" do
           it "returns false" do
             expect(subject).to eq(false)
-          end
-
-          it "adds an issue" do
-            expect(AddIssue).to receive(:call).with(user.id, barcode, anything).and_call_original
-            subject
-          end
-
-          it "destroys the item" do
-            expect(item).to receive(:destroy!)
-            subject
-          end
-
-          it "logs the activity" do
-            expect(LogActivity).to receive(:call).with(anything, "Destroyed", anything, anything, anything).ordered
-            subject
           end
         end
 
@@ -66,24 +63,32 @@ RSpec.describe SyncItemMetadata do
           let(:status_code) { 500 }
 
           it_behaves_like "an error response"
+
+          it_behaves_like "a metadata status update", "error"
         end
 
         context "not found error" do
           let(:status_code) { 404 }
 
           it_behaves_like "an error response"
+
+          it_behaves_like "a metadata status update", "not_found"
         end
 
         context "timeout error" do
           let(:status_code) { 599 }
 
           it_behaves_like "an error response"
+
+          it_behaves_like "a metadata status update", "error"
         end
 
         context "unauthorized error" do
           let(:status_code) { 401 }
 
           it_behaves_like "an error response"
+
+          it_behaves_like "a metadata status update", "error"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,6 +82,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     # Preload the fields for ActiveRecord objects to allow use of instance_double
     [
+      Item,
       User
     ].each do |database_model|
       instance = database_model.new


### PR DESCRIPTION
This is more groundwork for AIMS 212.

It adds a metadata status and timestamp which is used to determine if the item can be added to a tray.