### PR TITLE
AIMS-231 Show the metadata status of an item if it failed to load

### DIFF
--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -92,7 +92,7 @@ section {
     .doNotPrint, .doNotPrint * { display: none !important; }
 }
 
-.container > .navbar-header, 
+.container > .navbar-header,
   main > .navbar-header,
   .container > .navbar-collapse,
   main > .navbar-collapse,
@@ -214,8 +214,8 @@ a.list-group-item[aria-expanded="true"] {
   }
 }
 
-.navbar > .container .navbar-brand, 
-  .navbar > main .navbar-brand, 
+.navbar > .container .navbar-brand,
+  .navbar > main .navbar-brand,
   .navbar > .container-fluid .navbar-brand {
   margin-left: 0;
 }
@@ -236,9 +236,20 @@ hr {
 
     .field {
       margin-bottom: 1.5em;
-      
+
       label {
         margin-right: 12px;
+      }
+    }
+  }
+}
+
+.table-striped {
+  > tbody {
+    tr:nth-of-type(odd),
+    tr:nth-of-type(even) {
+      &.item-metadata-not_found {
+        background-color: $alert-danger-bg;
       }
     }
   }

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -248,7 +248,8 @@ hr {
   > tbody {
     tr:nth-of-type(odd),
     tr:nth-of-type(even) {
-      &.item-metadata-not_found {
+      &.item-metadata-not-found,
+      &.item-metadata-not-for-annex {
         background-color: $alert-danger-bg;
       }
     }

--- a/app/views/trays/show_item.html.haml
+++ b/app/views/trays/show_item.html.haml
@@ -29,7 +29,7 @@
       %th= 'Chron'
   %tbody
     - @tray.items.each do |item|
-      %tr{ class: "item-metadata-#{item.metadata_status}" }
+      %tr{ class: "item-metadata-#{item.metadata_status.to_s.gsub(/_/,'-')}" }
         %td{ style: "white-space:nowrap;" }
           = form_tag dissociate_tray_item_path(@tray) do |f|
             = hidden_field_tag :item_id, item.id
@@ -45,5 +45,8 @@
             = item.title
           - else
             = t "item.metadata_status.#{item.metadata_status}"
+            - if item.title.present?
+              %br
+              = item.title
         %td= item.chron
 

--- a/app/views/trays/show_item.html.haml
+++ b/app/views/trays/show_item.html.haml
@@ -29,7 +29,7 @@
       %th= 'Chron'
   %tbody
     - @tray.items.each do |item|
-      %tr
+      %tr{ class: "item-metadata-#{item.metadata_status}" }
         %td{ style: "white-space:nowrap;" }
           = form_tag dissociate_tray_item_path(@tray) do |f|
             = hidden_field_tag :item_id, item.id
@@ -40,6 +40,10 @@
         %td= item.status.titleize
         %td= item.barcode
         %td= item.thickness
-        %td= item.title
+        %td
+          - if item.metadata_status == "complete"
+            = item.title
+          - else
+            = t "item.metadata_status.#{item.metadata_status}"
         %td= item.chron
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  item:
+    metadata_status:
+      complete: "Metadata synchronized"
+      not_found: "Barcode not found"
+      pending: "Metadata sync pending"
+      error: "Error loading metadata, will retry automatically"
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,8 @@ en:
   item:
     metadata_status:
       complete: "Metadata synchronized"
+      error: "Error loading metadata, will retry automatically"
+      not_for_annex: "Item not flagged for annex"
       not_found: "Barcode not found"
       pending: "Metadata sync pending"
-      error: "Error loading metadata, will retry automatically"
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     call_number "#{('A'..'Z').to_a.sample}#{('A'..'Z').to_a.sample}#{Faker::Number.number(4)}.#{('A'..'Z').to_a.sample}#{Faker::Number.number(2)} #{(1900..2014).to_a.sample}"
     initial_ingest Faker::Date.between(2.days.ago, Date.today)
     last_ingest Date::today.to_s
+    metadata_status "complete"
   end
 
 end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SyncItemMetadata do
   let(:barcode) { "00000007819006" }
-  let(:item) { FactoryGirl.create(:item, barcode: barcode) }
+  let(:item) { FactoryGirl.create(:item, barcode: barcode, metadata_status: "pending") }
   let(:user) { FactoryGirl.create(:user) }
   let(:user_id) { user.id }
   let(:response) { ApiResponse.new(status_code: 200, body: {}) }


### PR DESCRIPTION
AIMS-231 - If an item that hasn't successfully synced with the API is stocked onto a tray, we need to display the status.

This will display the status of the metadata sync, and will highlight the row if it's not found or not for the annex.