### PR TITLE
Aims 181 remove request function

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,16 +1,13 @@
 class RequestsController < ApplicationController
-
   def remove
     request = Request.find(params[:request_id])
-    if (DestroyRequest.call(request, current_user))
+    if DestroyRequest.call(request, current_user)
       ApiRemoveRequest.call(request)
-      flash[:notice] = 'Request removed'
+      flash[:notice] = "Request removed"
     else
-      flash[:error] = 'Request NOT removed'
+      flash[:error] = "Request NOT removed"
     end
 
     redirect_to :back
-    
   end
-
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,0 +1,16 @@
+class RequestsController < ApplicationController
+
+  def remove
+    request = Request.find(params[:request_id])
+    if (DestroyRequest.call(request, current_user))
+      ApiRemoveRequest.call(request)
+      flash[:notice] = 'Request removed'
+    else
+      flash[:error] = 'Request NOT removed'
+    end
+
+    redirect_to :back
+    
+  end
+
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -5,7 +5,7 @@ class Request < ActiveRecord::Base
   validates_presence_of :source
   validates_presence_of :req_type
 
-  has_many :matches
+  has_many :matches, dependent: :destroy
   has_many :items, through: :matches
   has_many :batches, through: :matches
 

--- a/app/services/api_remove_request.rb
+++ b/app/services/api_remove_request.rb
@@ -1,0 +1,24 @@
+class ApiRemoveRequest
+  attr_reader :item_id
+
+  def self.call(request)
+    new(request).post_data!
+  end
+
+  def initialize(request)
+    @request = request
+  end
+
+  def post_data!
+    ApiHandler.post(:archive_request, post_params)
+  end
+
+  private
+
+  def post_params
+    {
+      source: @request.source,
+      transaction_num: @request.trans
+    }
+  end
+end

--- a/app/services/api_remove_request.rb
+++ b/app/services/api_remove_request.rb
@@ -10,7 +10,7 @@ class ApiRemoveRequest
   end
 
   def post_data!
-    ApiHandler.post(:archive_request, post_params)
+    ApiHandler.post(action: :archive_request, params: post_params)
   end
 
   private

--- a/app/services/destroy_request.rb
+++ b/app/services/destroy_request.rb
@@ -11,7 +11,8 @@ class DestroyRequest
   end
 
   def destroy
-    request.destroy!
-    LogActivity.call(request, "Destroyed", nil, Time.now, user)
+    status = request.destroy!
+    LogActivity.call(request, "Removed", nil, Time.now, user)
+    status
   end
 end

--- a/app/services/destroy_request.rb
+++ b/app/services/destroy_request.rb
@@ -1,0 +1,17 @@
+class DestroyRequest
+  attr_reader :request, :user
+
+  def self.call(request, user)
+    new(request, user).destroy
+  end
+
+  def initialize(request, user)
+    @request = request
+    @user = user
+  end
+
+  def destroy
+    request.destroy!
+    LogActivity.call(request, "Destroyed", nil, Time.now, user)
+  end
+end

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -19,6 +19,7 @@
         %th= 'Request Barcode'
         %th= 'Request ISSN/ISBN'
         %th= 'Request Bib Number'
+        %th= 'Remove Request'
     %tbody
       - @data.each do |row|
         %tr{"data-params" => row['item_data'].to_json}
@@ -33,6 +34,11 @@
           %td= row['barcode']
           %td= row['isbn_issn']
           %td= row['bib_number']
+          %td
+            = form_tag remove_request_path do |f|
+              = hidden_field_tag :request_id, row['id']
+              .actions
+                = submit_tag 'Remove', data: { confirm: 'Remove request?' }, class: 'btn btn-primary'
   .actions
     = submit_tag 'Save', class: 'btn btn-primary'
 :javascript

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,115 +6,66 @@ Rails.application.routes.draw do
 
   # These could be better organized, maybe. Nested resource routes might be better.
 
-  get 'trays/shelves', to: 'trays#index', as: 'trays'
-  post 'trays/shelves', to: 'trays#scan', as: 'scan_tray'
-  get 'trays/shelves/:id', to: 'trays#show', as: 'show_tray'
-  post 'trays/shelves/:id', to: 'trays#associate', as: 'associate_tray'
-  post 'trays/shelves/:id/dissociate', to: 'trays#dissociate', as: 'dissociate_tray'
-  post 'trays/shelves/:id/shelve', to: 'trays#shelve', as: 'shelve_tray'
-  post 'trays/shelves/:id/unshelve', to: 'trays#unshelve', as: 'unshelve_tray'
-  get 'trays/shelves/:id/wrong_shelf', to: 'trays#wrong_shelf', as: 'wrong_shelf'
-  get 'trays/shelves/:id/wrong_tray/:barcode', to: 'trays#wrong_tray', as: 'wrong_tray'
+  get "trays/shelves", to: "trays#index", as: "trays"
+  post "trays/shelves", to: "trays#scan", as: "scan_tray"
+  get "trays/shelves/:id", to: "trays#show", as: "show_tray"
+  post "trays/shelves/:id", to: "trays#associate", as: "associate_tray"
+  post "trays/shelves/:id/dissociate", to: "trays#dissociate", as: "dissociate_tray"
+  post "trays/shelves/:id/shelve", to: "trays#shelve", as: "shelve_tray"
+  post "trays/shelves/:id/unshelve", to: "trays#unshelve", as: "unshelve_tray"
+  get "trays/shelves/:id/wrong_shelf", to: "trays#wrong_shelf", as: "wrong_shelf"
+  get "trays/shelves/:id/wrong_tray/:barcode", to: "trays#wrong_tray", as: "wrong_tray"
 
-  get 'trays/items', to: 'trays#items', as: 'trays_items'
-  post 'trays/items', to: 'trays#scan_item', as: 'scan_tray_item'
-  get 'trays/items/:id', to: 'trays#show_item', as: 'show_tray_item'
-  post 'trays/items/:id', to: 'trays#associate_item', as: 'associate_tray_item'
-  post 'trays/items/:id/dissociate', to: 'trays#dissociate_item', as: 'dissociate_tray_item'
-  get 'trays/items/:id/missing', to: 'trays#missing', as: 'missing_tray_item'
+  get "trays/items", to: "trays#items", as: "trays_items"
+  post "trays/items", to: "trays#scan_item", as: "scan_tray_item"
+  get "trays/items/:id", to: "trays#show_item", as: "show_tray_item"
+  post "trays/items/:id", to: "trays#associate_item", as: "associate_tray_item"
+  post "trays/items/:id/dissociate", to: "trays#dissociate_item", as: "dissociate_tray_item"
+  get "trays/items/:id/missing", to: "trays#missing", as: "missing_tray_item"
 
-  post 'trays/:id/withdraw', to: 'trays#withdraw', as: 'withdraw_tray'
+  post "trays/:id/withdraw", to: "trays#withdraw", as: "withdraw_tray"
 
-  get 'shelves/items', to: 'shelves#index', as: 'shelves'
-  post 'shelves/items', to: 'shelves#scan', as: 'scan_shelf'
-  get 'shelves/items/:id', to: 'shelves#show', as: 'show_shelf'
-  post 'shelves/items/:id', to: 'shelves#associate', as: 'associate_shelf_item'
-  post 'shelves/items/:id/dissociate', to: 'shelves#dissociate', as: 'dissociate_shelf_item'
-  get 'shelves/items/:id/wrong/:barcode', to: 'shelves#wrong', as: 'wrong_shelf_item'
+  get "shelves/items", to: "shelves#index", as: "shelves"
+  post "shelves/items", to: "shelves#scan", as: "scan_shelf"
+  get "shelves/items/:id", to: "shelves#show", as: "show_shelf"
+  post "shelves/items/:id", to: "shelves#associate", as: "associate_shelf_item"
+  post "shelves/items/:id/dissociate", to: "shelves#dissociate", as: "dissociate_shelf_item"
+  get "shelves/items/:id/wrong/:barcode", to: "shelves#wrong", as: "wrong_shelf_item"
 
-  get 'items', to: 'items#index', as: 'items'
-  get 'items/scan', to: 'items#scan', as: 'scan_item'
-  get 'items/issues', to: 'items#issues', as: 'issues'
-  post 'items/resolve', to: 'items#resolve', as: 'resolve_issue'
-  get 'items/:id', to: 'items#show', as: 'show_item'
-  post 'items/:id/restock', to: 'items#restock', as: 'item_restock'
-  get 'items/:id/wrong_restock', to: 'items#wrong_restock', as: 'wrong_restock'
+  get "items", to: "items#index", as: "items"
+  get "items/scan", to: "items#scan", as: "scan_item"
+  get "items/issues", to: "items#issues", as: "issues"
+  post "items/resolve", to: "items#resolve", as: "resolve_issue"
+  get "items/:id", to: "items#show", as: "show_item"
+  post "items/:id/restock", to: "items#restock", as: "item_restock"
+  get "items/:id/wrong_restock", to: "items#wrong_restock", as: "wrong_restock"
 
-  get 'search', to: 'search#index', as: 'search'
+  get "search", to: "search#index", as: "search"
 
-  get 'batches', to: 'batches#index', as: 'batches'
-  post 'batches', to: 'batches#create', as: 'create_batch'
-  get 'batches/current', to: 'batches#current', as: 'current_batch'
-  post 'batches/remove', to: 'batches#remove', as: 'remove_batch_match'
-  get 'batches/retrieve', to: 'batches#retrieve', as: 'retrieve_batch'
-  post 'batches/item', to: 'batches#item', as: 'item_batch'
-  get 'batches/bin', to: 'batches#bin', as: 'bin_batch'
-  post 'batches/scan_bin', to: 'batches#scan_bin', as: 'scan_bin_batch'
-  get 'batches/finalize', to: 'batches#finalize', as: 'finalize_batch'
-  post 'batches/finish', to: 'batches#finish', as: 'finish_batch'
+  get "batches", to: "batches#index", as: "batches"
+  post "batches", to: "batches#create", as: "create_batch"
+  get "batches/current", to: "batches#current", as: "current_batch"
+  post "batches/remove", to: "batches#remove", as: "remove_batch_match"
+  get "batches/retrieve", to: "batches#retrieve", as: "retrieve_batch"
+  post "batches/item", to: "batches#item", as: "item_batch"
+  get "batches/bin", to: "batches#bin", as: "bin_batch"
+  post "batches/scan_bin", to: "batches#scan_bin", as: "scan_bin_batch"
+  get "batches/finalize", to: "batches#finalize", as: "finalize_batch"
+  post "batches/finish", to: "batches#finish", as: "finish_batch"
 
-  get 'batches/view/processed', to: 'batches#view_processed', as: 'view_processed_batches'
-  get 'batches/view/processed/:id', to: 'batches#view_single_processed', as: 'view_single_processed_batch'
+  get "batches/view/processed", to: "batches#view_processed", as: "view_processed_batches"
+  get "batches/view/processed/:id", to: "batches#view_single_processed", as: "view_single_processed_batch"
 
-  get 'batches/view/active', to: 'batches#view_active', as: 'view_active_batches'
-  get 'batches/view/active/:id', to: 'batches#view_single_active', as: 'view_single_active_batch'
-  post 'batches/view/active', to: 'batches#cancel_single_active', as: 'cancel_single_active_batch'
+  get "batches/view/active", to: "batches#view_active", as: "view_active_batches"
+  get "batches/view/active/:id", to: "batches#view_single_active", as: "view_single_active_batch"
+  post "batches/view/active", to: "batches#cancel_single_active", as: "cancel_single_active_batch"
 
-  get 'bins', to: 'bins#index', as: 'bins'
-  get 'bins/:id', to: 'bins#show', as: 'show_bin'
-  post 'bins', to: 'bins#remove', as: 'bin_remove'
+  get "bins", to: "bins#index", as: "bins"
+  get "bins/:id", to: "bins#show", as: "show_bin"
+  post "bins", to: "bins#remove", as: "bin_remove"
 
-  post 'requests/remove', to: 'requests#remove', as: 'remove_request'
+  post "requests/remove", to: "requests#remove", as: "remove_request"
 
   # You can have the root of your site routed with "root"
-  root 'welcome#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+  root "welcome#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
   get 'bins/:id', to: 'bins#show', as: 'show_bin'
   post 'bins', to: 'bins#remove', as: 'bin_remove'
 
+  post 'requests/remove', to: 'requests#remove', as: 'remove_request'
+
   # You can have the root of your site routed with "root"
   root 'welcome#index'
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -169,7 +169,6 @@ ActiveRecord::Schema.define(version: 20150625190556) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   add_foreign_key "batches", "users"
-  add_foreign_key "issues", "users"
   add_foreign_key "issues", "users", column: "resolver_id"
   add_foreign_key "items", "bins"
   add_foreign_key "items", "trays"

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     criteria_type "barcode"
     sequence(:criteria) { |n| "#{n}" }
     sequence(:barcode) { |n| "12345#{n}" }
+    sequence(:trans) { |n| "aleph_12345#{n}" }
     requested Faker::Date.between(2.days.ago, Date.today)
     rapid false
     source "aleph"

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :request do
     criteria_type "barcode"
     sequence(:criteria) { |n| "#{n}" }
+    sequence(:barcode) { |n| "12345#{n}" }
     requested Faker::Date.between(2.days.ago, Date.today)
     rapid false
     source "aleph"

--- a/spec/features/bins_spec.rb
+++ b/spec/features/bins_spec.rb
@@ -48,6 +48,7 @@ feature "Bins", :type => :feature do
     end
 
     it "can remove an item from a bin" do
+      stub_api_scan_send(match: @bin.matches[0])
       visit show_bin_path(:id => @bin.id)
       expect(page).to have_content @bin.matches[0].item.barcode
       expect(page).to have_content @bin.matches[0].item.title

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Request" do
+
+  let(:request) { FactoryGirl.create(:request) }
+
+  describe "#bin_type" do
+
+    context "when source is aleph" do
+
+      it "returns the correct bin type" do
+        expect(request.bin_type).to eq "ALEPH-LOAN" 
+      end
+    end
+
+    context "when source is not aleph" do
+
+      before(:each) do
+        request.source = 'ill'
+      end
+
+      context "when del_type is not loan" do
+
+        before(:each) do
+          request.del_type = "not loan"
+        end
+
+        it "returns the correct bin type" do
+          expect(request.bin_type).to eq "ILL-SCAN" 
+        end
+        
+      end
+
+      context "when del_type is loan" do
+
+        it "returns the correct bin type" do
+          expect(request.bin_type).to eq "ILL-LOAN" 
+        end
+      end
+      
+    end
+    
+  end
+  
+end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,20 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "Request" do
-
   let(:request) { FactoryGirl.create(:request) }
 
   describe "#bin_type" do
-
     context "when source is aleph" do
-
       it "returns the correct bin type" do
         expect(request.bin_type).to eq "ALEPH-LOAN"
       end
     end
 
     context "when source is not aleph" do
-
       before(:each) do
         request.source = "ill"
       end
@@ -30,7 +26,6 @@ RSpec.describe "Request" do
       end
 
       context "when del_type is loan" do
-
         it "returns the correct bin type" do
           expect(request.bin_type).to eq "ILL-LOAN"
         end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -9,37 +9,32 @@ RSpec.describe "Request" do
     context "when source is aleph" do
 
       it "returns the correct bin type" do
-        expect(request.bin_type).to eq "ALEPH-LOAN" 
+        expect(request.bin_type).to eq "ALEPH-LOAN"
       end
     end
 
     context "when source is not aleph" do
 
       before(:each) do
-        request.source = 'ill'
+        request.source = "ill"
       end
 
       context "when del_type is not loan" do
-
         before(:each) do
           request.del_type = "not loan"
         end
 
         it "returns the correct bin type" do
-          expect(request.bin_type).to eq "ILL-SCAN" 
+          expect(request.bin_type).to eq "ILL-SCAN"
         end
-        
       end
 
       context "when del_type is loan" do
 
         it "returns the correct bin type" do
-          expect(request.bin_type).to eq "ILL-LOAN" 
+          expect(request.bin_type).to eq "ILL-LOAN"
         end
       end
-      
     end
-    
   end
-  
 end

--- a/spec/services/api_remove_request_spec.rb
+++ b/spec/services/api_remove_request_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ApiRemoveRequest do
+  let(:user_id) { 1 }
+  let(:request) { FactoryGirl.create(:request) }
+
+  describe "#call" do
+    subject { described_class.call(request) }
+
+    it "responds with success" do
+      stub_api_remove_request(request: request, body: { 
+        "status" => "OK",
+        "message" => "Request removed" }.to_json)
+      expect(subject).to be_a_kind_of(ApiResponse)
+      expect(subject.success?).to eq(true)
+      expect(subject.body).to be_a_kind_of(Hash)
+      expect(subject.body["status"]).to eq("OK")
+    end
+
+    it "responds with an error when call fails" do
+      stub_api_remove_request(request: request, status_code: 500, body: {}.to_json)
+      expect(subject).to be_a_kind_of(ApiResponse)
+      expect(subject.error?).to eq(true)
+      expect(subject.body).to be_a_kind_of(Hash)
+    end
+  end
+end

--- a/spec/services/api_remove_request_spec.rb
+++ b/spec/services/api_remove_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApiRemoveRequest do
     subject { described_class.call(request) }
 
     it "responds with success" do
-      stub_api_remove_request(request: request, body: { 
+      stub_api_remove_request(request: request, body: {
         "status" => "OK",
         "message" => "Request removed" }.to_json)
       expect(subject).to be_a_kind_of(ApiResponse)

--- a/spec/services/destroy_request_spec.rb
+++ b/spec/services/destroy_request_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "DestroyRequest" do
+
+  let(:request) { FactoryGirl.create(:request) }
+  let(:request1) { FactoryGirl.create(:request) }
+  let(:user) { FactoryGirl.create(:user) }
+  subject { DestroyRequest.call(request, user)}
+
+  describe "#destroy" do
+
+    before(:each) do
+      request.save!
+      request1.save!
+    end
+
+    it "deletes one request" do
+      expect(Request.all.count).to eq 2
+      subject
+      expect(Request.all.count).to eq 1
+    end
+    
+  end
+
+end

--- a/spec/services/destroy_request_spec.rb
+++ b/spec/services/destroy_request_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 describe "DestroyRequest" do
-
   let(:request) { FactoryGirl.create(:request) }
   let(:request1) { FactoryGirl.create(:request) }
   let(:user) { FactoryGirl.create(:user) }
-  subject { DestroyRequest.call(request, user)}
+  subject { DestroyRequest.call(request, user) }
 
   describe "#destroy" do
 
@@ -19,10 +18,9 @@ describe "DestroyRequest" do
       subject
       expect(Request.all.count).to eq 1
     end
-    
-    it "returns true on success" do
-      expect(subject).to be_truthy  
-    end    
-  end
 
+    it "returns true on success" do
+      expect(subject).to be_truthy
+    end
+  end
 end

--- a/spec/services/destroy_request_spec.rb
+++ b/spec/services/destroy_request_spec.rb
@@ -7,7 +7,6 @@ describe "DestroyRequest" do
   subject { DestroyRequest.call(request, user) }
 
   describe "#destroy" do
-
     before(:each) do
       request.save!
       request1.save!

--- a/spec/services/destroy_request_spec.rb
+++ b/spec/services/destroy_request_spec.rb
@@ -20,6 +20,9 @@ describe "DestroyRequest" do
       expect(Request.all.count).to eq 1
     end
     
+    it "returns true on success" do
+      expect(subject).to be_truthy  
+    end    
   end
 
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -28,6 +28,10 @@ module ApiHelper
     api_url(:scan)
   end
 
+  def api_remove_request_url
+    api_url(:archive_request)
+  end
+
   def api_item_metadata_url(barcode)
     api_url(:record, barcode: barcode)
   end
@@ -64,6 +68,13 @@ module ApiHelper
       to_return(status: status_code, body: body, headers: {})
   end
 
+  def stub_api_remove_request(request: request, status_code: 200, body: nil)
+    stub_request(:post, api_remove_request_url).
+      with(body: api_remove_request_params(request),
+           headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: status_code, body: body, headers: {})
+  end
+
   def api_scan_send_delivery_type(match)
     if match.request.del_type == "scan"
       "scan"
@@ -81,6 +92,13 @@ module ApiHelper
       transaction_num: match.request.trans.to_s,
       request_type: match.request.req_type,
       delivery_type: api_scan_send_delivery_type(match)
+    }
+  end
+
+  def api_remove_request_params(request)
+    {
+      source: request.source,
+      transaction_num: request.trans
     }
   end
 


### PR DESCRIPTION
**What** Added functionality to allow users to remove (delete) requests for various reasons

**Why** They needed a way to arbitrarily reject requests that could not be fulfilled at the Annex and bounce them back to either Hesburgh cataloging and circ, or ILL.

**How** I created two service classes; one to delete requests, and the other to interact with the API to archive the request so that it won't show up in the active request list until the request issue is resolved. I also modified the request model so that it will also delete any associated "match" records. The button on the index.html.haml page that lists requests now has a button on it that is in a form that points to the appropriate controller method. The button is also tied to a confirmation message to avoid accidental deletions.

This is what the button looks like:

![screen shot 2015-06-30 at 3 19 47 pm](https://cloud.githubusercontent.com/assets/9285578/8439697/a7f48a7e-1f3b-11e5-89e7-680c0ae46de3.png)
