### PR TITLE
AIMS-221: Change IMS to return error if sublibrary != "Annex"

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,6 +16,7 @@ class Item < ActiveRecord::Base
     "pending",
     "complete",
     "not_found",
+    "not_for_annex",
     "error",
   ]
 

--- a/app/services/get_item_from_barcode.rb
+++ b/app/services/get_item_from_barcode.rb
@@ -39,7 +39,7 @@ class GetItemFromBarcode
   end
 
   def item_can_be_stocked?
-    item.metadata_status != "not_found"
+    !([ "not_found", "not_for_annex" ].include? item.metadata_status)
   end
 
   def user

--- a/app/services/get_item_from_barcode.rb
+++ b/app/services/get_item_from_barcode.rb
@@ -39,7 +39,7 @@ class GetItemFromBarcode
   end
 
   def item_can_be_stocked?
-    !([ "not_found", "not_for_annex" ].include? item.metadata_status)
+    !(["not_found", "not_for_annex"].include? item.metadata_status)
   end
 
   def user

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -65,13 +65,13 @@ class SyncItemMetadata
 
   def handle_error(error)
     save_metadata_status(error[:status])
-    if(error[:issue])
+    if error[:issue]
       AddIssue.call(user_id, barcode, error[:issue])
     end
-    if(error[:activity])
+    if error[:activity]
       LogActivity.call(item, error[:activity], nil, Time.now, user)
     end
-    if(error[:enqueue])
+    if error[:enqueue]
       process_in_background
     end
   end

--- a/spec/features/item_to_shelf_spec.rb
+++ b/spec/features/item_to_shelf_spec.rb
@@ -17,8 +17,26 @@ feature "Shelves", :type => :feature do
       login_user
 
       item_uri = api_item_url(@item)
+      response_body = {
+        "item_id" => "00110147500410",
+        "barcode" => @item.barcode,
+        "bib_id" => @item.bib_number,
+        "sequence_number" => "00410",
+        "admin_document_number" => "001101475",
+        "call_number" => @item.call_number,
+        "description" => @item.chron,
+        "title"=> @item.title,
+        "author" => @item.author,
+        "publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-",
+        "edition" => "",
+        "isbn_issn" => @item.isbn_issn,
+        "condition" => @item.conditions,
+        "sublibrary" => "ANNEX"
+      }.to_json
 
-      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions, "sublibrary" => "ANNEX" }.to_json, :headers => {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return { { status: 200, body: response_body, headers: {} } }
 
       stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
@@ -135,7 +153,25 @@ feature "Shelves", :type => :feature do
         item = FactoryGirl.create(:item, title: "Item #{i + 1}")
         @items << item
         item_uri = api_item_url(item)
-        stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, :headers => {} } }
+        response_body = {
+          "item_id" => "00110147500410",
+          "barcode" => item.barcode,
+          "bib_id" => item.bib_number,
+          "sequence_number" => "00410",
+          "admin_document_number" => "001101475",
+          "call_number" => item.call_number,
+          "description" => item.chron,
+          "title" => item.title,
+          "author" => item.author,
+          "publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-",
+          "edition" => "",
+          "isbn_issn" => item.isbn_issn,
+          "condition" => item.conditions,
+          "sublibrary" => "ANNEX"
+        }.to_json
+        stub_request(:get, item_uri).
+          with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+          to_return { { status: 200, body: response_body, headers: {} } }
         stub_request(:post, api_stock_url).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"TRAY-#{@shelf.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).

--- a/spec/features/item_to_shelf_spec.rb
+++ b/spec/features/item_to_shelf_spec.rb
@@ -18,7 +18,7 @@ feature "Shelves", :type => :feature do
 
       item_uri = api_item_url(@item)
 
-      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions, "sublibrary" => "ANNEX" }.to_json, :headers => {} } }
 
       stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
@@ -135,7 +135,7 @@ feature "Shelves", :type => :feature do
         item = FactoryGirl.create(:item, title: "Item #{i + 1}")
         @items << item
         item_uri = api_item_url(item)
-        stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, :headers => {} } }
+        stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, :headers => {} } }
         stub_request(:post, api_stock_url).
           with(:body => {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"TRAY-#{@shelf.barcode}"},
             :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -19,7 +19,7 @@ feature "Items", :type => :feature do
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
       item_uri = api_item_url(@item)
-      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
+      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions, "sublibrary"=>"ANNEX" }.to_json, :headers => {} } }
     end
 
     after(:each) do

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -10,16 +10,20 @@ feature "Items", :type => :feature do
       @tray = FactoryGirl.create(:tray)
       @shelf = FactoryGirl.create(:shelf)
       @tray2 = FactoryGirl.create(:tray)
-      @item = FactoryGirl.create(:item, tray: @tray, thickness: 1, title: 'ITEM 1', chron: 'TEST CHRON')
-      @item2 = FactoryGirl.create(:item, tray: @tray2, thickness: 2, title: 'ITEM 2', chron: 'TEST CHRON2')
+      @item = FactoryGirl.create(:item, tray: @tray, thickness: 1, title: "The ubiquity of chaos / edited by Saul Krasner.", chron: "Chron")
+      @item2 = FactoryGirl.create(:item, tray: @tray2, thickness: 2, title: "The ubiquity of chaos / edited by Saul Krasner.", chron: "Chron")
 
       stub_request(:post, api_stock_url).
         with(:body => {"barcode"=>"#{@item.barcode}", "item_id"=>"#{@item.id}", "tray_code"=>"#{@item.tray.barcode}"},
           :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
+      response_body = api_fixture_data("item_metadata.json")
+
       item_uri = api_item_url(@item)
-      stub_request(:get, item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions, "sublibrary"=>"ANNEX" }.to_json, :headers => {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
     end
 
     after(:each) do

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -7,12 +7,15 @@ feature "Trays", type: :feature do
   let(:tray) { FactoryGirl.create(:tray, barcode: tray_barcode) }
   let(:item) { FactoryGirl.create(:item) }
   let(:shelf) { FactoryGirl.create(:shelf) }
+  let(:response_body) { api_fixture_data("item_metadata.json") }
 
   describe "when signed in" do
     before(:each) do
       login_user
 
-      stub_request(:get, api_item_url(item)). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, "sublibrary"=>"ANNEX", headers: {} } }
+      stub_request(:get, api_item_url(item)).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
 
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
@@ -335,7 +338,9 @@ feature "Trays", type: :feature do
    it "accepts re-associating an item to the same tray" do
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, headers: {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent"=>"Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -370,7 +375,7 @@ feature "Trays", type: :feature do
       item = FactoryGirl.create(:item, tray: tray2)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
       stub_request(:post, api_stock_url).
-        with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray2.barcode}", "sublibrary"=>"ANNEX"},
+        with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray2.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { status: 200, body: {results: {status: "OK", message: "Item stocked"}}.to_json, headers: {} } }
       visit trays_items_path
@@ -393,7 +398,9 @@ feature "Trays", type: :feature do
 
     it "displays a tray's barcode while processing an item" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
       visit trays_items_path
       fill_in "Tray", with: tray.barcode
       click_button "Save"
@@ -440,7 +447,9 @@ feature "Trays", type: :feature do
 
     it "allows the user to remove an item from a tray" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -461,7 +470,9 @@ feature "Trays", type: :feature do
 
     it "allows the user to finish with the current tray when processing items" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -481,7 +492,9 @@ feature "Trays", type: :feature do
 
     it "allows the user to finish with the current tray when processing items via scan" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -12,7 +12,7 @@ feature "Trays", type: :feature do
     before(:each) do
       login_user
 
-      stub_request(:get, api_item_url(item)). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, headers: {} } }
+      stub_request(:get, api_item_url(item)). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, "sublibrary"=>"ANNEX", headers: {} } }
 
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
@@ -370,7 +370,7 @@ feature "Trays", type: :feature do
       item = FactoryGirl.create(:item, tray: tray2)
       expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
       stub_request(:post, api_stock_url).
-        with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray2.barcode}"},
+        with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray2.barcode}", "sublibrary"=>"ANNEX"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
         to_return{ |response| { status: 200, body: {results: {status: "OK", message: "Item stocked"}}.to_json, headers: {} } }
       visit trays_items_path
@@ -392,6 +392,8 @@ feature "Trays", type: :feature do
 
 
     it "displays a tray's barcode while processing an item" do
+      item_uri = api_item_url(item)
+      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
       visit trays_items_path
       fill_in "Tray", with: tray.barcode
       click_button "Save"
@@ -438,7 +440,7 @@ feature "Trays", type: :feature do
 
     it "allows the user to remove an item from a tray" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, headers: {} } }
+      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -459,7 +461,7 @@ feature "Trays", type: :feature do
 
     it "allows the user to finish with the current tray when processing items" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, headers: {} } }
+      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -479,7 +481,7 @@ feature "Trays", type: :feature do
 
     it "allows the user to finish with the current tray when processing items via scan" do
       item_uri = api_item_url(item)
-      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions}.to_json, headers: {} } }
+      stub_request(:get, item_uri). with(headers: {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { status: 200, body: {"item_id" => "00110147500410", "barcode" => item.barcode, "bib_id" => item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => item.call_number, "description" => item.chron ,"title"=> item.title, "author" => item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>item.isbn_issn, "condition" => item.conditions, "sublibrary" => "ANNEX" }.to_json, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).

--- a/spec/fixtures/api/item_metadata.json
+++ b/spec/fixtures/api/item_metadata.json
@@ -12,5 +12,6 @@
   "edition":"Edition",
   "isbn_issn":"0871683504",
   "condition":["Condition"],
+  "chron":"Chron",
   "sublibrary":"ANNEX"
 }

--- a/spec/fixtures/api/item_metadata.json
+++ b/spec/fixtures/api/item_metadata.json
@@ -11,5 +11,6 @@
   "publication":"Washington, DC : American Association for the Advancement of Science, 1990.",
   "edition":"Edition",
   "isbn_issn":"0871683504",
-  "condition":["Condition"]
+  "condition":["Condition"],
+  "sublibrary":"ANNEX"
 }

--- a/spec/services/item_path_spec.rb
+++ b/spec/services/item_path_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe ItemPath do
 
     stub_request(:get, item_uri).
          with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).
-         to_return(:status => 200, :body => '{"path":"http://bogus"}', :headers => {})
+         to_return(:status => 200, :body => '{"path":"http://bogus", "sublibrary":"ANNEX"}', :headers => {})
 
     stub_request(:get, item2_uri).
          with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).
-         to_return(:status => 200, :body => '{"path":"http://bogus"}', :headers => {})
+         to_return(:status => 200, :body => '{"path":"http://bogus", "sublibrary":"ANNEX"}', :headers => {})
 
 
     @user_id = 1 # Just fake having a user here

--- a/spec/services/item_path_spec.rb
+++ b/spec/services/item_path_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe ItemPath do
     item2_uri = api_item_url(@item2)
 
     stub_request(:get, item_uri).
-         with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).
-         to_return(:status => 200, :body => '{"path":"http://bogus", "sublibrary":"ANNEX"}', :headers => {})
+      with(headers: { "User-Agent"=>"Faraday v0.9.1" }).
+      to_return(status: 200, body: '{"path":"http://bogus", "sublibrary":"ANNEX"}', headers: {})
 
     stub_request(:get, item2_uri).
-         with(:headers => {'User-Agent'=>'Faraday v0.9.1'}).
-         to_return(:status => 200, :body => '{"path":"http://bogus", "sublibrary":"ANNEX"}', :headers => {})
+      with(headers: { "User-Agent"=>"Faraday v0.9.1" }).
+      to_return(status: 200, body: '{"path":"http://bogus", "sublibrary":"ANNEX"}', headers: {})
 
 
     @user_id = 1 # Just fake having a user here

--- a/spec/services/item_restock_spec.rb
+++ b/spec/services/item_restock_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe ItemRestock do
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
     stub_request(:get, item_uri).
-       with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
+       with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null, "sublibrary":"ANNEX" }', :headers => {})
 
     stub_request(:get, item2_uri).
-       with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null}', :headers => {})
+       with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null, "sublibrary":"ANNEX" }', :headers => {})
 
     @user_id = 1 # Just fake having a user here
   end

--- a/spec/services/item_restock_spec.rb
+++ b/spec/services/item_restock_spec.rb
@@ -21,11 +21,15 @@ RSpec.describe ItemRestock do
         :headers => {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
       to_return{ |response| { :status => 200, :body => {:results => {:status => "OK", :message => "Item stocked"}}.to_json, :headers => {} } }
 
+    response_body = api_fixture_data("item_metadata.json")
+
     stub_request(:get, item_uri).
-       with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null, "sublibrary":"ANNEX" }', :headers => {})
+      with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: 200, body: response_body, headers: {})
 
     stub_request(:get, item2_uri).
-       with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return(:status => 200, :body => '{"item_id":"00110147500410","barcode":"00000016021933","bib_id":"001101475","sequence_number":"00410","admin_document_number":"001101475","call_number":"QH 573 .T746","description":"v.11 :no.1-6  \u003Cp.1-276\u003E   (2001:Jan.-June)","title":"Trends in cell biology.","author":"","publication":"Cambridge, UK : Elsevier Science Publishers, c1991-","edition":"","isbn_issn":"0962-8924","condition":null, "sublibrary":"ANNEX" }', :headers => {})
+      with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+      to_return(status: 200, body: response_body, headers: {})
 
     @user_id = 1 # Just fake having a user here
   end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe SyncItemMetadata do
         end
 
         context "no sublibrary code" do
-          let(:body_json) { { }.to_json }
+          let(:body_json) { {}.to_json }
           let(:status_code) { 200 }
 
           it_behaves_like "a metadata status update", "not_for_annex"

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SyncItemMetadata do
   let(:item) { FactoryGirl.create(:item, barcode: barcode) }
   let(:user) { FactoryGirl.create(:user) }
   let(:user_id) { user.id }
-  let(:response) { ApiResponse.new(status_code: 200, body: {}) }
+  let(:response) { ApiResponse.new(status_code: 200, body: { sublibrary: "ANNEX" }) }
   let(:background) { false }
 
   context "self" do
@@ -25,6 +25,20 @@ RSpec.describe SyncItemMetadata do
           subject
           expect(item.metadata_updated_at).to be_present
           expect(Time.now - item.metadata_updated_at).to be < 1
+        end
+      end
+
+      shared_examples "an issue logger" do |expected_issue|
+        it "calls AddIssue with #{expected_issue}" do
+          expect(AddIssue).to receive(:call).with(user.id, barcode, expected_issue)
+          subject
+        end
+      end
+
+      shared_examples "an activity logger" do |expected_activity, expected_location|
+        it "calls LogActivity with #{expected_activity}" do
+          expect(LogActivity).to receive(:call).with(item, expected_activity, expected_location, anything, user)
+          subject
         end
       end
 
@@ -103,7 +117,7 @@ RSpec.describe SyncItemMetadata do
         end
 
         it "logs the activity" do
-          expect(LogActivity).to receive(:call).with(anything, "UpdatedByAPI", anything, anything, anything).ordered
+          expect(LogActivity).to receive(:call).with(anything, "MetadataUpdated", anything, anything, anything).ordered
           expect(subject).to eq(true)
         end
       end
@@ -120,8 +134,10 @@ RSpec.describe SyncItemMetadata do
       end
 
       context "error response" do
+        let(:body_json) { { sublibrary: "ANNEX" }.to_json }
+
         before do
-          stub_api_item_metadata(barcode: barcode, status_code: status_code, body: {}.to_json)
+          stub_api_item_metadata(barcode: barcode, status_code: status_code, body: body_json)
         end
 
         shared_examples "an error response" do
@@ -145,6 +161,10 @@ RSpec.describe SyncItemMetadata do
           it_behaves_like "a metadata status update", "error"
 
           it_behaves_like "a response that queues a background job"
+
+          it_behaves_like "an issue logger", "500"
+
+          it_behaves_like "an activity logger", "MetadataError500"
         end
 
         context "not found error" do
@@ -158,6 +178,10 @@ RSpec.describe SyncItemMetadata do
             expect(SyncItemMetadataJob).to_not receive(:perform_later)
             subject
           end
+
+          it_behaves_like "an issue logger", "Item not found."
+
+          it_behaves_like "an activity logger", "MetadataNotFound"
         end
 
         context "timeout error" do
@@ -168,6 +192,10 @@ RSpec.describe SyncItemMetadata do
           it_behaves_like "a metadata status update", "error"
 
           it_behaves_like "a response that queues a background job"
+
+          it_behaves_like "an issue logger", "API Timeout."
+
+          it_behaves_like "an activity logger", "MetadataTimeout"
         end
 
         context "unauthorized error" do
@@ -178,6 +206,32 @@ RSpec.describe SyncItemMetadata do
           it_behaves_like "a metadata status update", "error"
 
           it_behaves_like "a response that queues a background job"
+
+          it_behaves_like "an issue logger", "Unauthorized - Check API Key."
+
+          it_behaves_like "an activity logger", "MetadataUnauthorized"
+        end
+
+        context "no sublibrary code" do
+          let(:body_json) { { }.to_json }
+          let(:status_code) { 200 }
+
+          it_behaves_like "a metadata status update", "not_for_annex"
+
+          it_behaves_like "an issue logger", "Not marked for Annex"
+
+          it_behaves_like "an activity logger", "MetadataFoundNotMarkedForAnnex"
+        end
+
+        context "sublibrary code is not ANNEX" do
+          let(:body_json) { { sublibrary: "SOMETHINGELSE" }.to_json }
+          let(:status_code) { 200 }
+
+          it_behaves_like "a metadata status update", "not_for_annex"
+
+          it_behaves_like "an issue logger", "Not marked for Annex"
+
+          it_behaves_like "an activity logger", "MetadataFoundNotMarkedForAnnex"
         end
       end
     end


### PR DESCRIPTION
Why: The user needs to be notified immediately that the item should not be trayed if the sublibrary code is not marked for Annex.
How: SyncItemMetadata can now test for errors in the data even if the query is successful. When an item is not marked for annex, it will return a not_for_annex error which will trickle up to the user as an immediate "Item # not found" error.

NOTE: After merging this, you will no longer be able to pull books from the shelf for test data. You will need to find barcodes that have sublibrary codes of "ANNEX"