### PR TITLE
AIMS-213 run the stock item api request in the background.

### DIFF
--- a/app/jobs/api_stock_item_job.rb
+++ b/app/jobs/api_stock_item_job.rb
@@ -1,0 +1,7 @@
+class ApiStockItemJob < ActiveJob::Base
+  queue_as ApiWorker::QUEUE_NAME
+
+  def perform(item: item)
+    ApiPostStockItem.call(item: item)
+  end
+end

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -1,12 +1,12 @@
 class ApiPostStockItem
-  attr_reader :item_id
+  attr_reader :item
 
-  def self.call(item_id)
-    new(item_id).post_data!
+  def self.call(item: item)
+    new(item: item).post_data!
   end
 
-  def initialize(item_id)
-    @item_id = item_id
+  def initialize(item: item)
+    @item = item
   end
 
   def post_data!
@@ -21,10 +21,6 @@ class ApiPostStockItem
       barcode: item.barcode,
       tray_code: item.tray.barcode
     }
-  end
-
-  def item
-    @item ||= Item.find(item_id)
   end
 
 end

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -1,4 +1,6 @@
 class ApiPostStockItem
+  class ApiStockItemError < StandardError; end
+
   attr_reader :item
 
   def self.call(item: item)
@@ -10,7 +12,12 @@ class ApiPostStockItem
   end
 
   def post_data!
-    ApiHandler.post(action: :stock, params: params)
+    response = ApiHandler.post(action: :stock, params: params)
+    if response.success?
+      response
+    else
+      raise ApiStockItemError, "Error sending stock request to API. params: #{params.inspect}, response: #{response.inspect}"
+    end
   end
 
   private

--- a/app/services/stock_item.rb
+++ b/app/services/stock_item.rb
@@ -15,7 +15,7 @@ class StockItem
 
     item.stocked!
     UpdateIngestDate.call(item)
-    ApiPostStockItem.call(item.id) # A bit of a hack, because when this gets shifted to a background job we only want it stocked after a successful API call. For now, this will do.
+    ApiStockItemJob.perform_later(item: item)
 
     if item.save!
       LogActivity.call(item, "Stocked", item.tray, Time.now, user)

--- a/app/workers/api_worker.rb
+++ b/app/workers/api_worker.rb
@@ -1,0 +1,9 @@
+class ApiWorker < RetryWorker
+  WORKERS = 1
+  QUEUE_NAME = "annex_api"
+
+  from_queue QUEUE_NAME,
+             threads: 1,
+             timeout_job_after: 60,
+             prefetch: 1
+end

--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -50,6 +50,7 @@ namespace :sneakers do
       begin
         workers = []
         worker_classes = [
+          ApiWorker,
           ItemMetadataWorker,
         ]
         worker_classes.each do |worker_class|

--- a/spec/jobs/api_stock_item_job_spec.rb
+++ b/spec/jobs/api_stock_item_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe ApiStockItemJob, type: :job do
+  let(:item) { instance_double(Item) }
+
+  subject { described_class }
+
+  describe "#perform" do
+    it "calls ApiPostStockItem with set values and does not reject" do
+      expect(ApiPostStockItem).to receive(:call).with(item: item)
+      subject.perform_now(item: item)
+    end
+  end
+end

--- a/spec/services/api_post_stock_item_spec.rb
+++ b/spec/services/api_post_stock_item_spec.rb
@@ -17,11 +17,9 @@ RSpec.describe ApiPostStockItem do
         expect(subject.body).to eq("status" => "OK", "message" => "Item stocked")
       end
 
-      it "does not raise an exception on API failure" do
+      it "raises an exception on API failure" do
         stub_api_stock_item(item: item, status_code: 500, body: {}.to_json)
-        expect(subject).to be_a_kind_of(ApiResponse)
-        expect(subject.error?).to eq(true)
-        expect(subject.body).to eq({})
+        expect { subject }.to raise_error(described_class::ApiStockItemError)
       end
     end
   end

--- a/spec/services/api_post_stock_item_spec.rb
+++ b/spec/services/api_post_stock_item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApiPostStockItem do
     subject { described_class }
 
     describe "#call" do
-      subject { described_class.call(item.id) }
+      subject { described_class.call(item: item) }
 
       it "retrieves data" do
         stub_api_stock_item(item: item)

--- a/spec/services/stock_item_spec.rb
+++ b/spec/services/stock_item_spec.rb
@@ -36,5 +36,4 @@ RSpec.describe StockItem do
     expect(ApiStockItemJob).to receive(:perform_later).with(item: @item)
     subject
   end
-
 end

--- a/spec/services/stock_item_spec.rb
+++ b/spec/services/stock_item_spec.rb
@@ -32,4 +32,9 @@ RSpec.describe StockItem do
     expect(subject).to be(false)
   end
 
+  it "queues a background job" do
+    expect(ApiStockItemJob).to receive(:perform_later).with(item: @item)
+    subject
+  end
+
 end

--- a/spec/workers/api_worker_spec.rb
+++ b/spec/workers/api_worker_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe ApiWorker, type: :worker do
+  subject { described_class.new }
+
+  let (:queue) { subject.queue }
+
+  let (:queue_options) { queue.opts.to_hash }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#number_of_workers" do
+      it "is 1" do
+        expect(subject.number_of_workers).to eq(1)
+      end
+    end
+  end
+
+  describe "queue" do
+    it "uses the correct queue name" do
+      expect(queue.name).to eq("annex_api")
+    end
+
+    it "sets the correct queue options" do
+      expect(queue_options[:arguments]).to eq(:"x-dead-letter-exchange" => "annex_api-retry")
+      expect(queue_options[:handler]).to eq(Sneakers::Handlers::Maxretry)
+      expect(queue_options[:routing_key]).to eq(["annex_api"])
+      expect(queue_options[:threads]).to eq(1)
+      expect(queue_options[:timeout_job_after]).to eq(60)
+      expect(queue_options[:prefetch]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This adds an additional worker for processing non-metadata jobs, and it moves the ApiPostStockItem service to the background