### PR TITLE
AIMS-181 Bug fix for logging requests that don't have an item barcode

### DIFF
--- a/app/services/destroy_request.rb
+++ b/app/services/destroy_request.rb
@@ -11,8 +11,10 @@ class DestroyRequest
   end
 
   def destroy
+    request_copy = request.clone
+    request_copy.barcode = request_copy.trans
     status = request.destroy!
-    LogActivity.call(request, "Removed", nil, Time.now, user)
+    LogActivity.call(request_copy, "Removed", nil, Time.now, user)
     status
   end
 end


### PR DESCRIPTION
**WHAT** Bug fix to compensate for requests not attached to an item via barcode

**WHY** Request deletion needs to be logged even before an item match has been found

**HOW** I changed the destroy method so that it makes a clone of the request object, which is otherwise frozen, and sets the barcode to equal the trans value, which is a more reliable identifier for requests anyway.