### PR TITLE
AIMS-237: Hide unstock for unstocked items in Item->Shelf

### DIFF
--- a/app/views/shelves/show.html.haml
+++ b/app/views/shelves/show.html.haml
@@ -18,18 +18,21 @@
   %thead
     %tr
       %th= "#{@shelf.items.count} Item(s)"
+      %th= 'Status'
       %th= 'Barcode'
       %th= 'Title'
       %th= 'Chron'
   %tbody
     - @shelf.items.each do |item|
       %tr
-        %td
+        %td{ style: "white-space:nowrap;" }
           = form_tag dissociate_shelf_item_path(@shelf) do |f|
             = hidden_field_tag :item_id, item.id
-            .actions
+            .actions{ style: "display: inline-block;" }
               = submit_tag 'Remove', class: 'btn btn-primary'
-              = submit_tag 'Unstock', class: 'btn btn-secondary'
+              - if(item.status == 'stocked')
+                = submit_tag 'Unstock', class: 'btn btn-secondary'
+        %td= item.status.titleize
         %td= item.barcode
         %td= item.title
         %td= item.chron


### PR DESCRIPTION
Why: In Item Direct to Shelf, when unstocking an item there is no feedback to the user that the item is now unstocked, and the unstock button is still available.
How: 
-Added status code to the item list
-Changed the unstock button to only be shown when the status of the item is 'stocked'