### PR TITLE
AIMS-215 move send/scan API requests to the background

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: ruby
 rvm:
-- 2.1.4
+  - 2.1.4
 script: "bundle exec rspec spec --tag '~ignore:travis'"
 cache: bundler
-sudo: false
-before_install:
-- travis_retry gem install bundler
 before_script:
-- cp config/secrets.yml.travis config/secrets.yml
-- cp config/database.yml.travis config/database.yml
-- psql -c 'create database travis_ci_test;' -U postgres
+  - cp config/secrets.yml.travis config/secrets.yml
+  - cp config/database.yml.travis config/database.yml
+  - psql -c 'create database travis_ci_test;' -U postgres
 notifications:
   hipchat:
     rooms:

--- a/app/controllers/bins_controller.rb
+++ b/app/controllers/bins_controller.rb
@@ -12,14 +12,7 @@ class BinsController < ApplicationController
     @match = Match.find(params[:match_id])
     bin_id = @match.bin.id
 
-    LogActivity.call(@match.item, "Dissociated", @match.item.bin, Time.now, current_user)
-
-    @match.item.bin = nil
-    @match.item.save!
-    @match.bin = nil
-    @match.save!
-
-    ApiPostDeliverItem.call(@match.id, current_user)
+    ProcessMatch.call(match: @match, user: current_user)
 
     redirect_to show_bin_path(:id => bin_id)
   end

--- a/app/jobs/api_scan_send_job.rb
+++ b/app/jobs/api_scan_send_job.rb
@@ -1,0 +1,7 @@
+class ApiScanSendJob < ActiveJob::Base
+  queue_as ApiWorker::QUEUE_NAME
+
+  def perform(match:)
+    ApiPostDeliverItem.call(match: match)
+  end
+end

--- a/app/jobs/api_stock_item_job.rb
+++ b/app/jobs/api_stock_item_job.rb
@@ -1,7 +1,7 @@
 class ApiStockItemJob < ActiveJob::Base
   queue_as ApiWorker::QUEUE_NAME
 
-  def perform(item: item)
+  def perform(item:)
     ApiPostStockItem.call(item: item)
   end
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -7,14 +7,21 @@ class Batch < ActiveRecord::Base
   validates_presence_of :user_id
 
   def skipped_matches
-    self.matches.where("matches.processed = 'skipped'")
+    matches.where(processed: "skipped")
   end
 
   def unprocessed_matches_for_request(request)
-    self.matches.where("matches.processed IS NULL").where(request: request.id)
+    matches.where(processed: nil, request: request.id)
   end
 
   def current_match
-    self.matches.where("matches.processed IS NULL").joins(item: {tray: :shelf}).order("shelves.barcode").order("trays.barcode").order("items.title").order("items.chron").first
+    matches.
+      where(processed: nil).
+      includes(item: { tray: :shelf }).
+      order("shelves.barcode").
+      order("trays.barcode").
+      order("items.title").
+      order("items.chron").
+      take
   end
 end

--- a/app/services/process_match.rb
+++ b/app/services/process_match.rb
@@ -1,0 +1,50 @@
+class ProcessMatch
+  attr_reader :match, :user
+
+  def self.call(match:, user:)
+    new(match: match, user: user).process
+  end
+
+  def initialize(match:, user:)
+    @match = match
+    @user = user
+  end
+
+  def process
+    ActiveRecord::Base.transaction do
+      dissociate_bin
+      scan_send
+    end
+    notify_api
+    true
+  end
+
+  private
+
+  def delivery_type
+    if match.request.del_type == "scan"
+      "scan"
+    else
+      "send"
+    end
+  end
+
+  def dissociate_bin
+    LogActivity.call(match.item, "Dissociated", match.item.bin, Time.now, user)
+
+    match.item.update!(bin: nil)
+    match.update!(bin: nil)
+  end
+
+  def scan_send
+    if delivery_type == "send"
+      ShipItem.call(match.item, user)
+    else
+      ScanItem.call(match.item, user)
+    end
+  end
+
+  def notify_api
+    ApiScanSendJob.perform_later(match: match)
+  end
+end

--- a/app/services/scan_item.rb
+++ b/app/services/scan_item.rb
@@ -1,0 +1,31 @@
+class ScanItem
+  attr_reader :item, :user
+
+  def self.call(item, user)
+    new(item, user).scan!
+  end
+
+  def initialize(item, user)
+    @item = item
+    @user = user
+  end
+
+  def scan!
+    validate_input!
+
+    UnstockItem.call(item, user) # Just in case it's not already unstocked, make sure.
+    LogActivity.call(item, "Scanned", item.tray, Time.now, user)
+
+    item
+  end
+
+  private
+
+  def validate_input!
+    if IsObjectItem.call(item)
+      true
+    else
+      raise "object is not an item"
+    end
+  end
+end

--- a/app/views/batches/retrieve.html.haml
+++ b/app/views/batches/retrieve.html.haml
@@ -25,8 +25,8 @@
             %li= @match.request.article_title
       %td
         %ul
-          %li= @match.item.shelf.barcode
-          %li= @match.item.tray.barcode
+          %li= @match.item.shelf ? @match.item.shelf.barcode : "No Shelf"
+          %li= @match.item.tray ? @match.item.tray.barcode : "No Tray"
           %li= @match.item.barcode
           - if !@match.item.title.blank?
             %li= @match.item.title

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -19,7 +19,7 @@ production:
 development:
   solr:
     hostname: localhost
-    port: 8080
+    port: 8210
     # path: /solr/annex-ims
     log_level: WARNING
     read_timeout: 2

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,26 +17,32 @@ def call_number
 end
 
 100.times do |i|
-  Item.create(
-    barcode: Faker::Number.number(14),
+  Item.create!(
+    barcode: Faker::Number.number(14).to_s,
     title: Faker::Lorem.sentence,
     author: Faker::Name.name,
-    bib_number: "0037612#{Faker::Number.number(2)}",
+    bib_number: "00#{Faker::Number.number(7)}",
     isbn_issn: [true, false].sample ? Faker::Code.isbn : "#{Faker::Number.number(4)}-#{Faker::Number.number(4)}",
     conditions: [Item::CONDITIONS.sample, Item::CONDITIONS.sample, Item::CONDITIONS.sample, Item::CONDITIONS.sample].uniq,
     call_number: call_number,
     initial_ingest: Faker::Date.between(30.days.ago, Date.today),
     last_ingest: Time.now.strftime("%Y-%m-%d"),
+    metadata_status: "complete",
     thickness: 1,
   )
 end
 
 50.times do |i|
-  Request.create(criteria_type: "barcode",
-    criteria: Item.order("RANDOM()").first.barcode,
+  barcode = Item.order("RANDOM()").first.barcode
+  Request.create!(
+    criteria_type: "barcode",
+    criteria: barcode,
+    barcode: barcode,
+    title: "Seed Request #{barcode}"
     requested: Faker::Date.between(30.days.ago, Date.today),
     rapid: false,
     source: "Aleph",
     del_type: "loan",
-    req_type: "doc_del")
+    req_type: "doc_del",
+  )
 end

--- a/spec/jobs/api_scan_send_job_spec.rb
+++ b/spec/jobs/api_scan_send_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe ApiScanSendJob, type: :job do
+  let(:match) { instance_double(Match) }
+
+  subject { described_class }
+
+  describe "#perform" do
+    it "calls ApiPostDeliverItem with set values" do
+      expect(ApiPostDeliverItem).to receive(:call).with(match: match)
+      subject.perform_now(match: match)
+    end
+  end
+end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Batch do
+  let(:batch) { FactoryGirl.create(:batch) }
+
+  def create_item_with_tray_and_shelf(tray_barcode:, shelf_barcode:)
+    shelf = Shelf.where(barcode: shelf_barcode).take || FactoryGirl.create(:shelf, barcode: shelf_barcode)
+    tray = Tray.where(barcode: tray_barcode).take || FactoryGirl.create(:tray, barcode: tray_barcode, shelf: shelf)
+    FactoryGirl.create(:item, tray: tray)
+  end
+
+  it "has a valid factory" do
+    expect(batch).to be_valid
+  end
+
+  describe "#skipped_matches" do
+    it "is matches that were skipped" do
+      skipped_matches = FactoryGirl.create_list(:match, 2, processed: "skipped", batch: batch)
+      other_match = FactoryGirl.create(:match, processed: nil, batch: batch)
+      skipped_matches.each do |match|
+        expect(batch.skipped_matches).to include(match)
+      end
+      expect(batch.skipped_matches).to_not include(other_match)
+    end
+  end
+
+  describe "#unprocessed_matches_for_request" do
+    let(:request) { FactoryGirl.create(:request, del_type: "loan") }
+
+    it "is unprocessed matches for the request" do
+      matches = FactoryGirl.create_list(:match, 2, processed: nil, batch: batch, request: request)
+      other_match = FactoryGirl.create(:match, processed: "accepted", batch: batch, request: request)
+      matches.each do |match|
+        expect(batch.unprocessed_matches_for_request(request)).to include(match)
+      end
+      expect(batch.unprocessed_matches_for_request(request)).to_not include(other_match)
+    end
+  end
+
+  describe "#current_match" do
+    it "returns an unprocessed match for an item without a tray" do
+      unassigned_item = FactoryGirl.create(:item, tray: nil)
+      match = FactoryGirl.create(:match, processed: nil, batch: batch, item: unassigned_item)
+      expect(batch.current_match).to eq(match)
+    end
+
+    it "orders matches by shelf" do
+      first_item = create_item_with_tray_and_shelf(tray_barcode: "TRAY-AL1", shelf_barcode: "SHELF-1")
+      second_item = create_item_with_tray_and_shelf(tray_barcode: "TRAY-AH1", shelf_barcode: "SHELF-2")
+      second_match = FactoryGirl.create(:match, processed: nil, batch: batch, item: second_item)
+      first_match = FactoryGirl.create(:match, processed: nil, batch: batch, item: first_item)
+      expect(batch.current_match).to eq(first_match)
+      first_match.update!(processed: "accepted")
+      expect(batch.current_match).to eq(second_match)
+    end
+  end
+end

--- a/spec/services/process_match_spec.rb
+++ b/spec/services/process_match_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe ProcessMatch do
+  let(:shelf) { FactoryGirl.create(:shelf) }
+  let(:tray) { FactoryGirl.create(:tray, shelf: shelf) }
+  let(:item) { FactoryGirl.create(:item, tray: tray, thickness: 1) }
+  let(:bin) { FactoryGirl.create(:bin, items: [item]) }
+  let(:match) { FactoryGirl.create(:match, item: item, bin: bin, request: request) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:request) { FactoryGirl.create(:request, del_type: "loan") }
+
+  subject { described_class.call(match: match, user: user) }
+
+  it "processes a match" do
+    expect(subject).to eq(true)
+  end
+
+  it "dissociates the bin" do
+    subject
+    expect(match.bin).to be_nil
+    expect(item.bin).to be_nil
+  end
+
+  it "ships the item" do
+    expect(ShipItem).to receive(:call).with(item, user)
+    subject
+  end
+
+  context "scan request" do
+    let(:request) { FactoryGirl.create(:request, del_type: "scan") }
+
+    it "scans the item" do
+      expect(ScanItem).to receive(:call).with(item, user).and_call_original
+      subject
+    end
+  end
+
+  it "notifies the API" do
+    expect(ApiScanSendJob).to receive(:perform_later).with(match: match)
+    subject
+  end
+end

--- a/spec/services/scan_item_spec.rb
+++ b/spec/services/scan_item_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ScanItem do
+  let(:item) { FactoryGirl.create(:item, tray: tray) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:tray) { FactoryGirl.create(:tray) }
+
+  subject { described_class.call(item, user) }
+
+  it "works" do
+    subject
+  end
+
+  it "unstocks the item and logs the scan activity" do
+    expect(UnstockItem).to receive(:call).with(item, user)
+    expect(LogActivity).to receive(:call).with(item, "Scanned", item.tray, anything, user)
+    subject
+  end
+end

--- a/spec/services/ship_item_spec.rb
+++ b/spec/services/ship_item_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe ShipItem do
+  let(:item) { FactoryGirl.create(:item, tray: tray) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:tray) { FactoryGirl.create(:tray) }
+
+  subject { described_class.call(item, user) }
+
+  it "works" do
+    subject
+  end
+
+  it "unstocks the item and logs the scan activity" do
+    expect(LogActivity).to receive(:call).with(item, "Shipped", item.tray, anything, user)
+    subject
+  end
+end


### PR DESCRIPTION
This moves the scan/send API requests to a background job.

Other changes include:
Moved match processing out of the bin controller and into a service class.
Fixed a bug where batch retrieval failed when there isn't a tray and shelf associated with an item.
Move sunspot to a different port to avoid conflicting with other local solr instances.