### PR TITLE
Requeue item sync job in background

### DIFF
--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -151,6 +151,14 @@ RSpec.describe SyncItemMetadata do
             expect(SyncItemMetadataJob).to receive(:perform_later).with(item: item, user_id: user_id)
             subject
           end
+
+          context "in background" do
+            let(:background) { true }
+
+            it "raises an exception" do
+              expect { subject }.to raise_error(described_class::SyncItemMetadataError)
+            end
+          end
         end
 
         context "500 error" do


### PR DESCRIPTION
The item metadata jobs were not being requeued on failure.  In order to be requeued, an exception needs to be raised.