### PR TITLE
Aims 197 batch creation item status

### DIFF
--- a/app/services/build_request_data.rb
+++ b/app/services/build_request_data.rb
@@ -33,7 +33,7 @@ class BuildRequestData
 
       if !items.blank?
         items.each do |item|
-          temp = {'id' => "#{request.id}-#{item.id}", 'shelf' => (!item.shelf.nil? ? item.shelf.barcode : ''), 'tray' => (!item.tray.nil? ? item.tray.barcode : ''), 'title' => !item.title.nil? ? CGI.escapeHTML(item.title) : '', 'author' => !item.author.nil? ? CGI.escapeHTML(item.author) : '', 'chron' => !item.chron.nil? ? CGI.escapeHTML(item.chron) : ''}
+          temp = {'id' => "#{request.id}-#{item.id}", 'status' => item.status, 'shelf' => (!item.shelf.nil? ? item.shelf.barcode : ''), 'tray' => (!item.tray.nil? ? item.tray.barcode : ''), 'title' => !item.title.nil? ? CGI.escapeHTML(item.title) : '', 'author' => !item.author.nil? ? CGI.escapeHTML(item.author) : '', 'chron' => !item.chron.nil? ? CGI.escapeHTML(item.chron) : ''}
 
           request_data['item_data'] << temp
         end

--- a/app/services/build_request_data.rb
+++ b/app/services/build_request_data.rb
@@ -17,7 +17,8 @@ class BuildRequestData
       filter = {:criteria_type => request.criteria_type, :criteria => request.criteria}
       items = SearchItems.call(filter).results
 
-      request_data = {"requested" => request.requested,
+      request_data = {
+        "requested" => request.requested,
         "id" => request.id,
         "rapid" => (request.rapid ? "yes" : "no"),
         "source" => request.source,
@@ -29,7 +30,8 @@ class BuildRequestData
         "barcode" => request.barcode,
         "isbn_issn" => request.isbn_issn,
         "bib_number" => request.bib_number,
-        "item_data" => []}
+        "item_data" => []
+      }
 
       if !items.blank?
         items.each do |item|

--- a/app/services/build_request_data.rb
+++ b/app/services/build_request_data.rb
@@ -17,25 +17,33 @@ class BuildRequestData
       filter = {:criteria_type => request.criteria_type, :criteria => request.criteria}
       items = SearchItems.call(filter).results
 
-      request_data = {'requested' => request.requested,
-        'id' => request.id,
-        'rapid' => (request.rapid ? 'yes' : 'no'),
-        'source' => request.source,
-        'del_type' => request.del_type,
-        'req_type' => request.req_type,
-        'title' => request.title,
-        'author' => request.author,
-        'description' => request.description,
-        'barcode' => request.barcode,
-        'isbn_issn' => request.isbn_issn,
-        'bib_number' => request.bib_number,
-        'item_data' => []}
+      request_data = {"requested" => request.requested,
+        "id" => request.id,
+        "rapid" => (request.rapid ? "yes" : "no"),
+        "source" => request.source,
+        "del_type" => request.del_type,
+        "req_type" => request.req_type,
+        "title" => request.title,
+        "author" => request.author,
+        "description" => request.description,
+        "barcode" => request.barcode,
+        "isbn_issn" => request.isbn_issn,
+        "bib_number" => request.bib_number,
+        "item_data" => []}
 
       if !items.blank?
         items.each do |item|
-          temp = {'id' => "#{request.id}-#{item.id}", 'status' => item.status, 'shelf' => (!item.shelf.nil? ? item.shelf.barcode : ''), 'tray' => (!item.tray.nil? ? item.tray.barcode : ''), 'title' => !item.title.nil? ? CGI.escapeHTML(item.title) : '', 'author' => !item.author.nil? ? CGI.escapeHTML(item.author) : '', 'chron' => !item.chron.nil? ? CGI.escapeHTML(item.chron) : ''}
+          temp = {
+            "id" => "#{request.id}-#{item.id}",
+            "status" => item.status,
+            "shelf" => (!item.shelf.nil? ? item.shelf.barcode : ""),
+            "tray" => (!item.tray.nil? ? item.tray.barcode : ""),
+            "title" => !item.title.nil? ? CGI.escapeHTML(item.title) : "",
+            "author" => !item.author.nil? ? CGI.escapeHTML(item.author) : "",
+            "chron" => !item.chron.nil? ? CGI.escapeHTML(item.chron) : ""
+          }
 
-          request_data['item_data'] << temp
+          request_data["item_data"] << temp
         end
       end
 
@@ -43,7 +51,5 @@ class BuildRequestData
     end
 
     return data
-
   end
-
 end

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -134,7 +134,15 @@
       str += "<th>Chron</th>";
       $.each(json, function( index, item ) {
         str += "<tr>";
-        str += "<td><input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' /></td>";
+        if (item['status'] == 'stocked') {
+          str += "<td><input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' /></td>";
+        }
+        if (item['status'] == 'unstocked') {
+          str += "<td><span style='color: red'>Unstocked</span></td>";
+        }
+        if (item['status'] == 'shipped') {
+          str += "<td><span style='color: red'>Shipped</span></td>";
+        }
         str += "<td>"+item['shelf']+"</td>";
         str += "<td>"+item['tray']+"</td>";
         str += "<td>"+item['title']+"</td>";

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 20150625190556) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   add_foreign_key "batches", "users"
+  add_foreign_key "issues", "users"
   add_foreign_key "issues", "users", column: "resolver_id"
   add_foreign_key "items", "bins"
   add_foreign_key "items", "trays"


### PR DESCRIPTION
**What**: Enhanced item display on batch creation page to show messages based on item status, and prevent selection of item that is "unstocked" or "shipped"

**Why**: To prevent users from selecting items that are not on the shelf, but also give them information about the item status.

**How**: Modified index.html.haml page to include conditional logic based on item status (which is driven by javascript), and modified the build_request_data service class so that item metadata includes the status information.

![screen shot 2015-07-06 at 11 23 13 am](https://cloud.githubusercontent.com/assets/9285578/8525915/76c7d2fe-23d1-11e5-950b-703d86cbad4a.png)

![screen shot 2015-07-06 at 11 23 21 am](https://cloud.githubusercontent.com/assets/9285578/8525921/82ca898e-23d1-11e5-8b09-5e3a26608a6e.png)
