### PR TITLE
Fix a bug with removing a request (problem with nested forms), 

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,8 +1,8 @@
 class RequestsController < ApplicationController
   def remove
-    request = Request.find(params[:request_id])
+    request = Request.find(params[:id])
     if DestroyRequest.call(request, current_user)
-      ApiRemoveRequest.call(request)
+      ApiRemoveRequest.call(request: request)
       flash[:notice] = "Request removed"
     else
       flash[:error] = "Request NOT removed"

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -6,6 +6,10 @@ class ActivityLogger
     call(action: "ApiGetItemMetadata", item: item, params: params, api_response: api_response)
   end
 
+  def self.api_remove_request(request:, params:, api_response:)
+    call(action: "ApiRemoveRequest", request: request, params: params, api_response: api_response)
+  end
+
   def self.associate_item_and_bin(item:, bin:, user:)
     call(action: "AssociatedItemAndBin", user: user, item: item, bin: bin)
   end

--- a/app/services/api_remove_request.rb
+++ b/app/services/api_remove_request.rb
@@ -1,24 +1,26 @@
 class ApiRemoveRequest
-  attr_reader :item_id
+  attr_reader :request
 
-  def self.call(request)
-    new(request).post_data!
+  def self.call(request:)
+    new(request: request).post_data!
   end
 
-  def initialize(request)
+  def initialize(request:)
     @request = request
   end
 
   def post_data!
-    ApiHandler.post(action: :archive_request, params: post_params)
+    response = ApiHandler.post(action: :archive_request, params: params)
+    ActivityLogger.api_remove_request(request: request, params: params, api_response: response)
+    response
   end
 
   private
 
-  def post_params
+  def params
     {
-      source: @request.source,
-      transaction_num: @request.trans
+      source: request.source,
+      transaction_num: request.trans
     }
   end
 end

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -35,10 +35,8 @@
           %td= row['isbn_issn']
           %td= row['bib_number']
           %td
-            = form_tag remove_request_path do |f|
-              = hidden_field_tag :request_id, row['id']
-              .actions
-                = submit_tag 'Remove', data: { confirm: 'Remove request?' }, class: 'btn btn-primary'
+            .actions
+              = link_to "Remove", remove_request_path(row["id"]), method: :delete, data: { confirm: 'Remove request?' }, class: 'btn btn-primary'
   .actions
     = submit_tag 'Save', class: 'btn btn-primary'
 :javascript
@@ -147,7 +145,7 @@
         str += "<td>"+item['tray']+"</td>";
         str += "<td>"+item['title']+"</td>";
         str += "<td>"+item['author']+"</td>";
-        str += "<td>"+item['chron']+"</td>"; 
+        str += "<td>"+item['chron']+"</td>";
         str += "</tr>";
       } );
       str += "</table>";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
   get "bins/:id", to: "bins#show", as: "show_bin"
   post "bins", to: "bins#remove", as: "bin_remove"
 
-  post "requests/remove", to: "requests#remove", as: "remove_request"
+  delete "requests/remove/:id", to: "requests#remove", as: "remove_request"
 
   # You can have the root of your site routed with "root"
   root "welcome#index"

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe ActivityLogger do
     it_behaves_like "an activity log", "ApiGetItemMetadata"
   end
 
+  context "ApiRemoveRequest" do
+    let(:arguments) { { request: request, params: { test: "test" }, api_response: api_response } }
+    subject { described_class.api_remove_request(**arguments) }
+
+    it_behaves_like "an activity log", "ApiRemoveRequest"
+  end
+
   context "AssociatedItemAndBin" do
     let(:arguments) { { item: item, bin: bin, user: user } }
     subject { described_class.associate_item_and_bin(**arguments) }

--- a/spec/services/api_remove_request_spec.rb
+++ b/spec/services/api_remove_request_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe ApiRemoveRequest do
   let(:request) { FactoryGirl.create(:request) }
 
   describe "#call" do
-    subject { described_class.call(request) }
+    subject { described_class.call(request: request) }
 
     it "responds with success" do
       stub_api_remove_request(request: request, body: {
         "status" => "OK",
         "message" => "Request removed" }.to_json)
+      expect(ActivityLogger).to receive(:api_remove_request).with(request: request, params: {source: request.source, transaction_num: request.trans}, api_response: kind_of(ApiResponse))
       expect(subject).to be_a_kind_of(ApiResponse)
       expect(subject.success?).to eq(true)
       expect(subject.body).to be_a_kind_of(Hash)

--- a/spec/services/api_remove_request_spec.rb
+++ b/spec/services/api_remove_request_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ApiRemoveRequest do
   let(:user_id) { 1 }
   let(:request) { FactoryGirl.create(:request) }
+  let(:expected_params) { { source: request.source, transaction_num: request.trans } }
+
 
   describe "#call" do
     subject { described_class.call(request: request) }
@@ -11,7 +13,7 @@ RSpec.describe ApiRemoveRequest do
       stub_api_remove_request(request: request, body: {
         "status" => "OK",
         "message" => "Request removed" }.to_json)
-      expect(ActivityLogger).to receive(:api_remove_request).with(request: request, params: {source: request.source, transaction_num: request.trans}, api_response: kind_of(ApiResponse))
+      expect(ActivityLogger).to receive(:api_remove_request).with(request: request, params: expected_params, api_response: kind_of(ApiResponse))
       expect(subject).to be_a_kind_of(ApiResponse)
       expect(subject.success?).to eq(true)
       expect(subject.body).to be_a_kind_of(Hash)


### PR DESCRIPTION
There was a bug with removing the first request in the batch list, which was caused by nested forms.  This using the link_to method to avoid creating a form.

Also adds logging of the api remove request call for AIMS-248.