### PR TITLE
AIMS-233 update item issues

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,7 +1,9 @@
 class Issue < ActiveRecord::Base
-  validates :user_id, presence: true
+  ISSUE_TYPES = ["not_found", "not_for_annex"]
+
   validates :barcode, presence: true
-  validates :message, presence: true
+  validates :issue_type, presence: true, inclusion: ISSUE_TYPES
+  validates :user_id, presence: true
 
   belongs_to :user
   belongs_to :resolver, class_name: "User"

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -1,5 +1,5 @@
 class ActivityLogger
-  DATA_OBJECTS = [:item, :tray, :shelf, :bin, :request, :api_response, :params]
+  DATA_OBJECTS = [:item, :tray, :shelf, :bin, :request, :issue, :api_response, :params]
   attr_reader :action, :user, :data_objects
 
   def self.api_get_item_metadata(item:, params:, api_response:)
@@ -16,6 +16,10 @@ class ActivityLogger
 
   def self.associate_tray_and_shelf(tray:, shelf:, user:)
     call(action: "AssociatedTrayAndShelf", user: user, tray: tray, shelf: shelf)
+  end
+
+  def self.create_issue(issue:, item:)
+    call(action: "CreatedIssue", issue: issue, item: item)
   end
 
   def self.create_item(item:, user:)

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -69,8 +69,8 @@ class SyncItemMetadata
 
   def handle_error(error)
     save_metadata_status(error[:status])
-    if error[:issue]
-      AddIssue.call(user_id, barcode, error[:issue])
+    if error[:issue_type]
+      AddIssue.call(item: item, user_id: user_id, type: error[:issue_type])
     end
     if error[:enqueue]
       process_in_background(error)
@@ -84,13 +84,13 @@ class SyncItemMetadata
     if response.success?
       get_data_error(response)
     elsif response.not_found?
-      { type: :not_found, status: :not_found, issue: "Item not found." }
+      { type: :not_found, status: :not_found, issue_type: "not_found" }
     elsif response.unauthorized?
-      { type: :unauthorized, status: :error, issue: "Unauthorized - Check API Key.", enqueue: true }
+      { type: :unauthorized, status: :error, enqueue: true }
     elsif response.timeout?
-      { type: :timeout, status: :error, issue: "API Timeout.", enqueue: true }
+      { type: :timeout, status: :error, enqueue: true }
     else
-      { type: :unknown, status: :error, issue: "#{response.status_code}", enqueue: true }
+      { type: :unknown, status: :error, enqueue: true }
     end
   end
 
@@ -99,7 +99,7 @@ class SyncItemMetadata
   # otherwise if there are no errors with the data, will return nil
   def get_data_error(response)
     if !(response.body.has_key?(:sublibrary)) || response.body[:sublibrary] != "ANNEX"
-      { type: :not_for_annex, status: :not_for_annex, issue: "Not marked for Annex" }
+      { type: :not_for_annex, status: :not_for_annex, issue_type: "not_for_annex" }
     else
       nil
     end

--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -15,7 +15,7 @@
         %tr
           %td= issue.user.username
           %td= issue.barcode
-          %td= issue.message
+          %td= t "issues.issue_type.#{issue.issue_type}"
           %td= issue.created_at
           %td
             = form_tag resolve_issue_path do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,4 +27,8 @@ en:
       not_for_annex: "Item not flagged for annex"
       not_found: "Barcode not found"
       pending: "Metadata sync pending"
+  issues:
+    issue_type:
+      not_found: "Barcode not found."
+      not_for_annex: "Item not marked for annex."
 

--- a/db/migrate/20150706191200_delete_existing_issues.rb
+++ b/db/migrate/20150706191200_delete_existing_issues.rb
@@ -1,0 +1,8 @@
+class DeleteExistingIssues < ActiveRecord::Migration
+  class Issue < ActiveRecord::Base
+  end
+
+  def change
+    Issue.destroy_all
+  end
+end

--- a/db/migrate/20150706191210_add_issue_type_to_issues.rb
+++ b/db/migrate/20150706191210_add_issue_type_to_issues.rb
@@ -1,0 +1,6 @@
+class AddIssueTypeToIssues < ActiveRecord::Migration
+  def change
+    add_column :issues, :issue_type, :string, null: false
+    remove_column :issues, :message
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150706164456) do
+ActiveRecord::Schema.define(version: 20150706191210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,11 +51,11 @@ ActiveRecord::Schema.define(version: 20150706164456) do
   create_table "issues", force: :cascade do |t|
     t.integer  "user_id",     null: false
     t.string   "barcode",     null: false
-    t.text     "message",     null: false
     t.integer  "resolver_id"
     t.datetime "resolved_at"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "issue_type",  null: false
   end
 
   add_index "issues", ["resolver_id"], name: "index_issues_on_resolver_id", using: :btree

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :issue do
     user
     sequence(:barcode) { |n| "0000000#{n}" }
-    message ["Item not found.", "Unauthorized - Check API Key.", "API Timeout."].sample
+    issue_type ["not_for_annex", "not_found"].sample
   end
 
 end

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ActivityLogger do
   let(:tray) { FactoryGirl.create(:tray) }
   let(:shelf) { FactoryGirl.create(:shelf) }
   let(:user) { FactoryGirl.create(:user) }
+  let(:issue) { FactoryGirl.create(:issue) }
   let(:request) { FactoryGirl.create(:request) }
   let(:api_response) { ApiResponse.new(status_code: 200, body: { status: "OK" }) }
 
@@ -73,6 +74,13 @@ RSpec.describe ActivityLogger do
     subject { described_class.associate_tray_and_shelf(**arguments) }
 
     it_behaves_like "an activity log", "AssociatedTrayAndShelf"
+  end
+
+  context "CreatedIssue" do
+    let(:arguments) { { issue: issue, item: item } }
+    subject { described_class.create_issue(**arguments) }
+
+    it_behaves_like "an activity log", "CreatedIssue"
   end
 
   context "CreatedItem" do

--- a/spec/services/add_issue_spec.rb
+++ b/spec/services/add_issue_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe AddIssue do
+  let(:item) { FactoryGirl.create(:item) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:issue_type) { "not_found" }
+  subject { described_class.call(item: item, user_id: user.id, type: issue_type) }
+
+  it "creates an issue with the correct type, barcode and user" do
+    expect { subject }.to change { Issue.count }.from(0).to(1)
+    expect(subject.user).to eq(user)
+    expect(subject.issue_type).to eq(issue_type)
+    expect(subject.barcode).to eq(item.barcode)
+  end
+
+  it "logs the issue creation" do
+    expect(ActivityLogger).to receive(:create_issue).with(item: item, issue: kind_of(Issue))
+    subject
+  end
+
+  it "does not create a second issue for the same type" do
+    issue = described_class.call(item: item, user_id: user.id, type: issue_type)
+    expect(subject).to eq(issue)
+  end
+
+  it "creates a second issue for a different type" do
+    issue = described_class.call(item: item, user_id: user.id, type: "not_for_annex")
+    expect(subject).to_not eq(issue)
+  end
+
+  it "creates a second for a different item" do
+    other_item = FactoryGirl.create(:item)
+    issue = described_class.call(item: other_item, user_id: user.id, type: issue_type)
+    expect(subject).to_not eq(issue)
+  end
+end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe SyncItemMetadata do
         end
       end
 
-      shared_examples "an issue logger" do |expected_issue|
-        it "calls AddIssue with #{expected_issue}" do
-          expect(AddIssue).to receive(:call).with(user.id, barcode, expected_issue)
+      shared_examples "an issue logger" do |expected_issue_type|
+        it "calls AddIssue with #{expected_issue_type}" do
+          expect(AddIssue).to receive(:call).with(item: item, user_id: user.id, type: expected_issue_type)
           subject
         end
       end
@@ -162,8 +162,6 @@ RSpec.describe SyncItemMetadata do
           it_behaves_like "a metadata status update", "error"
 
           it_behaves_like "a response that queues a background job"
-
-          it_behaves_like "an issue logger", "500"
         end
 
         context "not found error" do
@@ -178,7 +176,7 @@ RSpec.describe SyncItemMetadata do
             subject
           end
 
-          it_behaves_like "an issue logger", "Item not found."
+          it_behaves_like "an issue logger", "not_found"
         end
 
         context "timeout error" do
@@ -189,8 +187,6 @@ RSpec.describe SyncItemMetadata do
           it_behaves_like "a metadata status update", "error"
 
           it_behaves_like "a response that queues a background job"
-
-          it_behaves_like "an issue logger", "API Timeout."
         end
 
         context "unauthorized error" do
@@ -201,8 +197,6 @@ RSpec.describe SyncItemMetadata do
           it_behaves_like "a metadata status update", "error"
 
           it_behaves_like "a response that queues a background job"
-
-          it_behaves_like "an issue logger", "Unauthorized - Check API Key."
         end
 
         context "no sublibrary code" do
@@ -211,7 +205,7 @@ RSpec.describe SyncItemMetadata do
 
           it_behaves_like "a metadata status update", "not_for_annex"
 
-          it_behaves_like "an issue logger", "Not marked for Annex"
+          it_behaves_like "an issue logger", "not_for_annex"
         end
 
         context "sublibrary code is not ANNEX" do
@@ -220,7 +214,7 @@ RSpec.describe SyncItemMetadata do
 
           it_behaves_like "a metadata status update", "not_for_annex"
 
-          it_behaves_like "an issue logger", "Not marked for Annex"
+          it_behaves_like "an issue logger", "not_for_annex"
         end
       end
     end


### PR DESCRIPTION
Currently issues are being added every time a metadata API error is encountered.  The following changes are a part of this pull request:

1) Rather than store a full message, store an issue_type value (i.e. not_found, not_for_annex)
2) Items should only have issues generated for the metadata statuses of "not_found" and "not_for_annex".  Remove the other AddIssue calls
3) If an open issues already exists for a given barcode and issue_type, do not add a new issue.