### PR TITLE
Spec performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 - cp config/secrets.yml.travis config/secrets.yml
 - cp config/database.yml.travis config/database.yml
 - psql -c 'create database travis_ci_test;' -U postgres
-script: "bundle exec rspec spec --tag '~ignore:travis'"
+script: "bundle exec rspec spec"
 notifications:
   hipchat:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
 addons:
   postgresql: "9.4"
 before_script:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
 - cp config/secrets.yml.travis config/secrets.yml
 - cp config/database.yml.travis config/database.yml
 - psql -c 'create database travis_ci_test;' -U postgres

--- a/spec/features/batches_spec.rb
+++ b/spec/features/batches_spec.rb
@@ -4,7 +4,7 @@ feature "Build", :type => :feature, :search => true do
   include SolrSpecHelper
   include AuthenticationHelper
 
-  describe "when signed in", ignore: :travis, js: true do
+  describe "when signed in", js: true do
 
     let(:shelf) { FactoryGirl.build(:shelf) }
     let(:tray) { FactoryGirl.build(:tray, barcode: 'TRAY-AH12345', shelf: shelf) }

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -4,7 +4,7 @@ feature "Search", :type => :feature, :search => true do
   include SolrSpecHelper
   include AuthenticationHelper
 
-  describe "when signed in", ignore: :travis do
+  describe "when signed in" do
 
     let(:shelf) { FactoryGirl.create(:shelf) }
     let(:tray) { FactoryGirl.create(:tray, barcode: 'TRAY-AH12345', shelf: shelf) }

--- a/spec/services/build_batch_spec.rb
+++ b/spec/services/build_batch_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe BuildBatch, search: true do
   include SolrSpecHelper
 
-  describe "when signed in", ignore: :travis do
+  describe "when signed in" do
 
     let(:shelf) { FactoryGirl.create(:shelf) }
     let(:tray) { FactoryGirl.create(:tray, barcode: "TRAY-AH12346", shelf: shelf) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,9 +71,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do |example|
-    # Feature specs can't easily be isolated within a transaction, so we use the truncation strategy here.
+    # Feature specs that make use of Capybara's javascript driver can't easily be isolated
+    #  within a transaction, so we use the truncation strategy here.
     #  See: https://github.com/DatabaseCleaner/database_cleaner/issues/273
-    if [:feature, :request].include? example.metadata[:type]
+    #       https://mattbrictson.com/faster-capybara-specs
+    if example.metadata[:js]
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction

--- a/spec/support/solr_spec_helper.rb
+++ b/spec/support/solr_spec_helper.rb
@@ -8,14 +8,14 @@ module SolrSpecHelper
       $sunspot = ::Sunspot::Rails::Server.new
 
       pid = fork do
-        STDERR.reopen('/dev/null')
-        STDOUT.reopen('/dev/null')
+        STDERR.reopen("/dev/null")
+        STDOUT.reopen("/dev/null")
         $sunspot.run
       end
       # shut down the Solr server
-      at_exit { Process.kill('TERM', pid) }
+      at_exit { Process.kill("TERM", pid) }
       # wait for solr to start
-      20.times do |i|
+      20.times do
         if solr_running?
           break
         end
@@ -29,8 +29,8 @@ module SolrSpecHelper
   def solr_running?
     if $sunspot
       response = nil
-      Net::HTTP.start('localhost', $sunspot.port) do |http|
-        response = http.head('/solr/')
+      Net::HTTP.start("localhost", $sunspot.port) do |http|
+        response = http.head("/solr/")
       end
       response.class == Net::HTTPOK
     end

--- a/spec/support/solr_spec_helper.rb
+++ b/spec/support/solr_spec_helper.rb
@@ -15,9 +15,26 @@ module SolrSpecHelper
       # shut down the Solr server
       at_exit { Process.kill('TERM', pid) }
       # wait for solr to start
-      sleep 5
+      20.times do |i|
+        if solr_running?
+          break
+        end
+        sleep 0.5
+      end
     end
 
     ::Sunspot.session = $original_sunspot_session
+  end
+
+  def solr_running?
+    if $sunspot
+      response = nil
+      Net::HTTP.start('localhost', $sunspot.port) do |http|
+        response = http.head('/solr/')
+      end
+      response.class == Net::HTTPOK
+    end
+  rescue Errno::ECONNREFUSED
+    false
   end
 end

--- a/spec/support/sunspot.rb
+++ b/spec/support/sunspot.rb
@@ -1,1 +1,0 @@
-Sunspot.session = Sunspot::Rails::StubSessionProxy.new(Sunspot.session)


### PR DESCRIPTION
We only need the truncation database cleaner strategy for examples that use the Capybara js driver.  The change to spec_helper `if example.metadata[:js]` cuts off several seconds.

I also added a check to the solr spec helper to monitor the status of the test instance.  That cuts off a couple seconds for the full suite as well.