### PR TITLE
AIMS-251: Add SkippedItem to ActivityLog

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -83,6 +83,8 @@ class BatchesController < ApplicationController
       @match.processed = "skipped"
       @match.save!
 
+      ActivityLogger.skip_item(item: @match.item, request: @match.request, user: current_user)
+
       redirect_to retrieve_batch_path
       return
     else

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -62,6 +62,10 @@ class ActivityLogger
     call(action: "ShippedItem", item: item, request: request, user: user)
   end
 
+  def self.skip_item(item:, request:, user:)
+    call(action: "SkippedItem", user: user, item: item, request: request)
+  end
+
   def self.stock_item(item:, tray:, user:)
     call(action: "StockedItem", user: user, item: item, tray: tray)
   end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe BatchesController, :type => :controller do
+RSpec.describe BatchesController, type: :controller do
   let(:user) { FactoryGirl.create(:user) }
   let(:batch) { FactoryGirl.create(:batch, user: user) }
   let(:match) { FactoryGirl.create(:match, batch: batch) }
@@ -13,7 +13,7 @@ RSpec.describe BatchesController, :type => :controller do
     it "logs a SkippedItem activity" do
       allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
       expect(ActivityLogger).to receive(:skip_item)
-      get :item, { commit: 'Skip' }
+      get :item, commit: "Skip"
     end
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe BatchesController, :type => :controller do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:batch) { FactoryGirl.create(:batch, user: user) }
+  let(:match) { FactoryGirl.create(:match, batch: batch) }
+
+  before(:each) do
+    sign_in(user)
+  end
+
+  describe "GET item" do
+    it "logs a SkippedItem activity" do
+      allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
+      expect(ActivityLogger).to receive(:skip_item)
+      get :item, { commit: 'Skip' }
+    end
+  end
+end

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -153,6 +153,13 @@ RSpec.describe ActivityLogger do
     it_behaves_like "an activity log", "ShippedItem"
   end
 
+  context "SkippedItem" do
+    let(:arguments) { { item: item, request: request, user: user } }
+    subject { described_class.skip_item(**arguments) }
+
+    it_behaves_like "an activity log", "SkippedItem"
+  end
+
   context "StockedItem" do
     let(:arguments) { { item: item, tray: tray, user: user } }
     subject { described_class.stock_item(**arguments) }


### PR DESCRIPTION
Why: Need to track when an item has been skipped during batch processing
How: Added a skip_item method to ActivityLogger and updated BatchesController to call it when an item is skipped.