### PR TITLE
AIMS-262: Don't log UnstockedItem if an item is not associated to a tray

### DIFF
--- a/app/services/unstock_item.rb
+++ b/app/services/unstock_item.rb
@@ -16,7 +16,9 @@ class UnstockItem
     item.unstocked!
 
     if item.save!
-      ActivityLogger.unstock_item(item: item, tray: item.tray, user: user)
+      unless item.tray.nil?
+        ActivityLogger.unstock_item(item: item, tray: item.tray, user: user)
+      end
       item
     else
       false

--- a/spec/services/unstock_item_spec.rb
+++ b/spec/services/unstock_item_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe UnstockItem do
     expect(subject).to be(false)
   end
 
+  context "no associated tray" do
+    let(:tray) { nil }
+
+    it "doesn't log the activity" do
+      expect(ActivityLogger).not_to receive(:unstock_item).with(item: item, tray: tray, user: user)
+      subject
+    end
+
+    it "still flags it as unstocked" do
+      expect(item).to receive(:unstocked!)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
Why: Adding an item to a bin currently calls UnstockItem, which will changed the status of the item and log an UnstockedItem activity. This can happen whether the Item was associated with a tray or not. If an item is not yet associated with a tray, we don't want it to log an UnstockedItem activity.
How: Changed UnstockedItem to not log if it does not have an associated tray.