### PR TITLE
AIMS-250: Add AcceptedItem to ActivityLog

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -95,6 +95,7 @@ class BatchesController < ApplicationController
         return
       else
         flash[:notice] = "Item #{@match.item.barcode} scanned."
+        ActivityLogger.accept_item(item: @match.item, request: @match.request, user: current_user)
         redirect_to bin_batch_path
         return
       end

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -2,6 +2,10 @@ class ActivityLogger
   DATA_OBJECTS = [:item, :tray, :shelf, :bin, :request, :issue, :api_response, :params]
   attr_reader :action, :user, :data_objects
 
+  def self.accept_item(item:, request:, user:)
+    call(action: "AcceptedItem", user: user, item: item, request: request)
+  end
+
   def self.api_get_item_metadata(item:, params:, api_response:)
     call(action: "ApiGetItemMetadata", item: item, params: params, api_response: api_response)
   end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe BatchesController, type: :controller do
   end
 
   describe "GET item" do
-    it "logs a SkippedItem activity" do
+    it "logs a SkippedItem activity on Skip" do
       allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
       expect(ActivityLogger).to receive(:skip_item)
       get :item, commit: "Skip"
+    end
+
+    it "logs an AcceptedItem activity on Save" do
+      allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
+      expect(ActivityLogger).to receive(:accept_item)
+      get :item, { commit: "Save", barcode: match.item.barcode }
     end
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe BatchesController, type: :controller do
     it "logs an AcceptedItem activity on Save" do
       allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
       expect(ActivityLogger).to receive(:accept_item)
-      get :item, { commit: "Save", barcode: match.item.barcode }
+      get :item, commit: "Save", barcode: match.item.barcode
     end
   end
 end

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe ActivityLogger do
     end
   end
 
+  context "AcceptedItem" do
+    let(:arguments) { { item: item, user: user, request: request } }
+    subject { described_class.accept_item(**arguments) }
+
+    it_behaves_like "an activity log", "AcceptedItem"
+  end
+
   context "ApiGetItemMetadata" do
     let(:arguments) do
       {


### PR DESCRIPTION
Why: Need to track when an item has been accepted during batch processing
How: Added an accept_item method to ActivityLogger and updated BatchesController to call it when an item is accepted.