### PR TITLE
AIMS-165 add a cron job for retrieving requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :application do
   # Use postgresql as the database for Active Record
   gem "pg", "~> 0.18.2"
   # Use SCSS for stylesheets
-  gem "sass-rails", "~> 4.0"
+  gem "sass-rails", "~> 5.0"
   # Use Uglifier as compressor for JavaScript assets
   gem "uglifier", ">= 1.3.0"
   # Use CoffeeScript for .coffee assets and views
@@ -25,7 +25,7 @@ group :application do
   gem "haml-rails"
 
   # Use Bootstrap because I"m not a designer
-  gem "bootstrap-sass", "3.3.5"
+  gem "bootstrap-sass", "~> 3.3.5"
   gem "autoprefixer-rails"
 
   # Someone already Rails-ified a nice datepicker for Bootstrap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,9 +83,9 @@ GEM
       debug_inspector (>= 0.0.1)
     bootstrap-datepicker-rails (1.3.1.1)
       railties (>= 3.0)
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     builder (3.2.2)
     bunny (1.7.0)
       amq-protocol (>= 1.9.2)
@@ -202,7 +202,6 @@ GEM
       haml (>= 3.1, < 5.0)
       railties (>= 4.0.1)
     highline (1.6.21)
-    hike (1.2.3)
     hitimes (1.2.2)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -236,7 +235,7 @@ GEM
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
-    multi_json (1.11.1)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -328,12 +327,13 @@ GEM
     rubycas-client (2.3.9)
       activesupport
     safe_yaml (1.0.4)
-    sass (3.2.19)
-    sass-rails (4.0.5)
+    sass (3.4.15)
+    sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
-      sass (~> 3.2.2)
-      sprockets (~> 2.8, < 3.0)
-      sprockets-rails (~> 2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (~> 1.1)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -354,11 +354,8 @@ GEM
     spring (1.2.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (2.12.4)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.2.0)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     sprockets-rails (2.3.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
@@ -416,7 +413,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-datepicker-rails
-  bootstrap-sass (= 3.3.5)
+  bootstrap-sass (~> 3.3.5)
   byebug
   capistrano (~> 3.4)
   capistrano-rails (~> 1.1)
@@ -453,7 +450,7 @@ DEPENDENCIES
   rails-erd
   rails_layout
   rspec-rails (~> 3.0)
-  sass-rails (~> 4.0)
+  sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sneakers
   spring

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -171,25 +171,10 @@ a.list-group-item[aria-expanded="true"] {
   }
 }
 
-.list-group-item-success {
-  .glyphicon {
-    font-size: 18px;
-    vertical-align: top;
-  }
-}
-
 .list-group-item-success[aria-expanded="true"] {
   .glyphicon-plus:before {
-    content: "-";
+    content: "\2212";
   }
-
-}
-
-.list-group-item-success[aria-expanded="false"] {
-  .glyphicon-plus:before {
-    content: "+";
-  }
-
 }
 
 .navbar {

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,7 +1,7 @@
 class BatchesController < ApplicationController
 
   def index
-    GetRequests.call(current_user.id) # This should go in a queue or scheduler to run periodically.
+    GetRequests.call # This should go in a queue or scheduler to run periodically.
 
     # Should this be in a service object? It's a relatively simple one-liner.
     requests = Request.all.where("id NOT IN (SELECT request_id FROM matches WHERE processed IS NULL OR processed != 'skipped')")

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,8 +1,6 @@
 class BatchesController < ApplicationController
 
   def index
-    GetRequests.call # This should go in a queue or scheduler to run periodically.
-
     # Should this be in a service object? It's a relatively simple one-liner.
     requests = Request.all.where("id NOT IN (SELECT request_id FROM matches WHERE processed IS NULL OR processed != 'skipped')")
     @data = BuildRequestData.call(requests)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
 
   def scan
     begin
-      @item = GetItemFromBarcode.call(current_user.id, params[:item][:barcode])
+      @item = GetItemFromBarcode.call(barcode: params[:item][:barcode], user_id: current_user.id)
     rescue StandardError => e
       flash[:error] = e.message
       redirect_to items_path

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -10,4 +10,11 @@ class RequestsController < ApplicationController
 
     redirect_to :back
   end
+
+  def sync
+    requests = GetRequests.call
+    flash[:notice] = I18n.t("requests.synchronized", count: requests.count)
+
+    redirect_to :back
+  end
 end

--- a/app/controllers/shelves_controller.rb
+++ b/app/controllers/shelves_controller.rb
@@ -31,7 +31,7 @@ class ShelvesController < ApplicationController
 
     thickness = 1 # Because we don't care about thickness here, it just needs to be something valid.
 
-    item = GetItemFromBarcode.call(current_user.id, barcode)
+    item = GetItemFromBarcode.call(barcode: barcode, user_id: current_user.id)
 
     if item.nil?
       flash[:error] = I18n.t("errors.barcode_not_found", barcode: barcode)

--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -106,7 +106,7 @@ class TraysController < ApplicationController
   def wrong_tray
     @tray = Tray.find(params[:id])
     @barcode = params[:barcode]
-    @item = GetItemFromBarcode.call(current_user.id, @barcode)
+    @item = GetItemFromBarcode.call(barcode: @barcode, user_id: current_user.id)
   end
 
 
@@ -152,7 +152,7 @@ class TraysController < ApplicationController
       return
     end
 
-    item = GetItemFromBarcode.call(current_user.id, barcode)
+    item = GetItemFromBarcode.call(barcode: barcode, user_id: current_user.id)
 
     if item.nil?
       flash[:error] = I18n.t("errors.barcode_not_found", barcode: barcode)

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -1,12 +1,11 @@
 class ApiGetRequestList
-  attr_reader :user_id
+  class ApiGetRequestsError < StandardError; end
 
-  def self.call(user_id)
-    new(user_id).get_data!
+  def self.call
+    new.get_data!
   end
 
-  def initialize(user_id)
-    @user_id = user_id
+  def initialize
   end
 
   def get_data!
@@ -14,66 +13,9 @@ class ApiGetRequestList
 
     response = ApiHandler.get(action: :active_requests)
     if response.success?
-      requests = parse_requests(response.body[:requests])
+      response
+    else
+      raise ApiGetRequestsError, "Error getting active requests from API. response: #{response.inspect}"
     end
-
-    ApiResponse.new(status_code: response.status_code, body: requests)
   end
-
-  def parse_requests(requests_data)
-    requests = []
-    requests_data.each do |res|
-      if !res["barcode"].blank?
-        criteria_type = "barcode"
-        criteria = res["barcode"]
-        GetItemFromBarcode.call(user_id, res["barcode"]) # Hack to make sure data is present for display.
-      elsif !res["bib_number"].blank?
-        criteria_type = "bib_number"
-        criteria = res["bib_number"]
-      elsif !res["isbn_issn"].blank?
-        criteria_type = "isbn_issn"
-        criteria = res["isbn_issn"]
-      elsif !res["title"].blank?
-        criteria_type = "title"
-        criteria = res["title"]
-      else
-        criteria_type = "ERROR" # Quick hack to cover when not available.
-        criteria = "ERROR"
-      end
-
-      del_type = res["delivery_type"].downcase
-      source = res["source"].downcase
-
-      req_type = res["request_type"].downcase.gsub(" ", "_")
-
-      if (res["rush"] == "No") || (res["rush"] == "Regular")
-        rapid = false
-      else
-        rapid = true
-      end
-
-      trans = res["transaction"].gsub("doc-del", "aleph").gsub("-", "_")
-
-      requests << { # Will add more info when rebuilding the batch page. Needs a migration.
-        "trans" => trans,
-        "criteria_type" => criteria_type,
-        "criteria" => criteria,
-        "requested" => Date.today.to_s, # Should be date requested, but that doesn"t seem available.
-        "rapid" => rapid,
-        "source" => source,
-        "del_type" => del_type,
-        "req_type" => req_type,
-        "title" => res["title"],
-        "article_title" => res["article_title"],
-        "author" => res["author"],
-        "description" => res["description"],
-        "barcode" => res["barcode"],
-        "isbn_issn" => res["isbn_issn"],
-        "bib_number" => res["bib_number"]
-      }
-    end
-
-    requests
-  end
-
 end

--- a/app/services/associate_shelf_with_item_barcode.rb
+++ b/app/services/associate_shelf_with_item_barcode.rb
@@ -16,7 +16,7 @@ class AssociateShelfWithItemBarcode
     validate_input!
     user = User.find(user_id)
     tray = GetTrayFromBarcode.call("TRAY-#{@shelf.barcode}")
-    item = GetItemFromBarcode.call(user_id, barcode)
+    item = GetItemFromBarcode.call(barcode: barcode, user_id: user_id)
 
     if tray.items.include?(item)
       StockItem.call(item, user)

--- a/app/services/associate_tray_with_item_barcode.rb
+++ b/app/services/associate_tray_with_item_barcode.rb
@@ -15,7 +15,7 @@ class AssociateTrayWithItemBarcode
   def associate!
     validate_input!
 
-    item = GetItemFromBarcode.call(user_id, barcode)
+    item = GetItemFromBarcode.call(barcode: barcode, user_id: user_id)
     if !item.nil?
       item.tray = tray
       item.thickness = thickness

--- a/app/services/get_item_from_barcode.rb
+++ b/app/services/get_item_from_barcode.rb
@@ -1,11 +1,11 @@
 class GetItemFromBarcode
   attr_reader :user_id, :barcode
 
-  def self.call(user_id, barcode)
-    new(user_id, barcode).get
+  def self.call(barcode:, user_id:)
+    new(barcode: barcode, user_id: user_id).get
   end
 
-  def initialize(user_id, barcode)
+  def initialize(barcode:, user_id:)
     @user_id = user_id
     @barcode = barcode
   end
@@ -43,7 +43,9 @@ class GetItemFromBarcode
   end
 
   def user
-    @user ||= User.find(user_id)
+    if user_id
+      @user ||= User.find(user_id)
+    end
   end
 
   def valid?

--- a/app/services/get_requests.rb
+++ b/app/services/get_requests.rb
@@ -1,24 +1,82 @@
 class GetRequests
-  def self.call(user_id)
-    new(user_id).get_data!
+  def self.call
+    new.get_data!
   end
 
-  def initialize(user_id)
-    @user_id = user_id
+  def initialize
   end
 
   def get_data!
-    response = ApiGetRequestList.call(@user_id)
+    response = ApiGetRequestList.call
 
-    if response.success?
-      response.body.each do |res|
-        r = Request.find_or_initialize_by(trans: res["trans"])
-        r.attributes = res
-        r.save!
-      end
-    else
-      raise "error getting request list"
-    end
+    update_requests(response.body[:requests])
   end
 
+  private
+
+  def update_requests(requests_data)
+    requests = []
+    requests_data.each do |request_data|
+      attributes = request_attributes(request_data)
+      requests << create_or_update_request(attributes)
+    end
+    requests
+  end
+
+  def create_or_update_request(attributes)
+    request = Request.find_or_initialize_by(trans: attributes["trans"])
+    request.attributes = attributes
+    request.save!
+    request
+  end
+
+  def request_attributes(request_data)
+    if !request_data["barcode"].blank?
+      criteria_type = "barcode"
+      criteria = request_data["barcode"]
+    elsif !request_data["bib_number"].blank?
+      criteria_type = "bib_number"
+      criteria = request_data["bib_number"]
+    elsif !request_data["isbn_issn"].blank?
+      criteria_type = "isbn_issn"
+      criteria = request_data["isbn_issn"]
+    elsif !request_data["title"].blank?
+      criteria_type = "title"
+      criteria = request_data["title"]
+    else
+      criteria_type = "ERROR" # Quick hack to cover when not available.
+      criteria = "ERROR"
+    end
+
+    del_type = request_data["delivery_type"].downcase
+    source = request_data["source"].downcase
+
+    req_type = request_data["request_type"].downcase.gsub(" ", "_")
+
+    if (request_data["rush"] == "No") || (request_data["rush"] == "Regular")
+      rapid = false
+    else
+      rapid = true
+    end
+
+    trans = request_data["transaction"].gsub("doc-del", "aleph").gsub("-", "_")
+
+    {
+      "trans" => trans,
+      "criteria_type" => criteria_type,
+      "criteria" => criteria,
+      "requested" => Date.today.to_s, # Should be date requested, but that doesn"t seem available.
+      "rapid" => rapid,
+      "source" => source,
+      "del_type" => del_type,
+      "req_type" => req_type,
+      "title" => request_data["title"],
+      "article_title" => request_data["article_title"],
+      "author" => request_data["author"],
+      "description" => request_data["description"],
+      "barcode" => request_data["barcode"],
+      "isbn_issn" => request_data["isbn_issn"],
+      "bib_number" => request_data["bib_number"]
+    }
+  end
 end

--- a/app/services/item_path.rb
+++ b/app/services/item_path.rb
@@ -17,7 +17,7 @@ class ItemPath
     results[:notice] = nil
     results[:path] = nil
 
-    item = GetItemFromBarcode.call(user_id, barcode)
+    item = GetItemFromBarcode.call(barcode: barcode, user_id: user_id)
 
     if item.blank?
       results[:error] = "No item was found with barcode #{barcode}"

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -1,7 +1,15 @@
-= select_tag :source, options_for_select([["Aleph", "aleph"], ["ILLiad", "illiad"]]), onchange: "table.draw();"
-= select_tag :req_type, options_for_select([["Loan", "loan"], ["Scan", "scan"]]), onchange: "table.draw();"
-= label_tag :rapid, "ILLiad Rapid Requests"
-= check_box_tag :rapid, 1, false, onchange: "table.draw();"
+.row
+  .col-md-8
+    = select_tag :source, options_for_select([["Aleph", "aleph"], ["ILLiad", "illiad"]]), onchange: "table.draw();"
+    = select_tag :req_type, options_for_select([["Loan", "loan"], ["Scan", "scan"]]), onchange: "table.draw();"
+    = label_tag :rapid, "ILLiad Rapid Requests"
+    = check_box_tag :rapid, 1, false, onchange: "table.draw();"
+  .col-md-4
+    .pull-right
+      = link_to sync_requests_path, method: :post, class: 'btn btn-primary' do
+        %span.glyphicon.glyphicon-refresh
+        = "Refresh"
+%br
 = form_tag create_batch_path do |f|
   %table.table.table-striped.condensed.datatable{"id" => "requests"}
     %thead

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,4 +33,6 @@ en:
     issue_type:
       not_found: "Barcode not found."
       not_for_annex: "Item not marked for annex."
+  requests:
+    synchronized: "Synchronized %{count} requests."
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,14 @@ Rails.application.routes.draw do
   get "bins/:id", to: "bins#show", as: "show_bin"
   post "bins", to: "bins#remove", as: "bin_remove"
 
-  delete "requests/remove/:id", to: "requests#remove", as: "remove_request"
+  resources :requests, only: [] do
+    collection do
+      post :sync
+    end
+    member do
+      delete :remove
+    end
+  end
 
   # You can have the root of your site routed with "root"
   root "welcome#index"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,3 +24,7 @@ set :output, File.join("log", "cron.log")
 every 1.hour do
   rake "sneakers:ensure_running"
 end
+
+every 15.minutes do
+  rake "annex:get_active_requests"
+end

--- a/lib/tasks/annex.rake
+++ b/lib/tasks/annex.rake
@@ -1,0 +1,13 @@
+namespace :annex do
+  desc "Retrieves active requests from the API and creates or updates local request records"
+  task get_active_requests: :environment do
+    begin
+      logger = Logger.new(STDOUT)
+      requests = GetRequests.call
+      logger.info("[annex:get_active_requests] Retrieved #{requests.count} requests.")
+    rescue StandardError => e
+      NotifyError.call(exception: e)
+      raise e
+    end
+  end
+end

--- a/lib/tasks/annex.rake
+++ b/lib/tasks/annex.rake
@@ -4,7 +4,8 @@ namespace :annex do
     begin
       logger = Logger.new(STDOUT)
       requests = GetRequests.call
-      logger.info("[annex:get_active_requests] Retrieved #{requests.count} requests.")
+      message = I18n.t("requests.synchronized", count: requests.count)
+      logger.info("[annex:get_active_requests] #{message}")
     rescue StandardError => e
       NotifyError.call(exception: e)
       raise e

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -314,7 +314,7 @@ feature "Trays", type: :feature do
       expect(page).to have_content item.chron
     end
 
-   it "displays information about a successful association made" do
+    it "displays information about a successful association made" do
       expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
       stub_request(:post, api_stock_url).
       with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
@@ -333,9 +333,9 @@ feature "Trays", type: :feature do
       expect(page).to have_content item.thickness
       expect(page).to have_content item.chron
       expect(page).to have_content "Item #{item.barcode} stocked in #{tray.barcode}."
-   end
+    end
 
-   it "accepts re-associating an item to the same tray" do
+    it "accepts re-associating an item to the same tray" do
       expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
@@ -367,10 +367,10 @@ feature "Trays", type: :feature do
       expect(page).to have_content item.thickness
       expect(page).to have_content item.chron
       expect(page).to have_content "Item #{item.barcode} already assigned to #{tray.barcode}. Record updated."
-   end
+    end
 
 
-   it "rejects associating an item to the wrong tray" do
+    it "rejects associating an item to the wrong tray" do
       tray2 = FactoryGirl.create(:tray)
       item = FactoryGirl.create(:item, tray: tray2)
       expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
@@ -393,7 +393,7 @@ feature "Trays", type: :feature do
       expect(page).to_not have_content "Item #{item.barcode} stocked in #{tray.barcode}."
       click_button "OK"
       expect(current_path).to eq(show_tray_item_path(id: tray.id))
-   end
+    end
 
 
     it "displays a tray's barcode while processing an item" do

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -295,7 +295,7 @@ feature "Trays", type: :feature do
     end
 
     it "displays an item after successfully adding it to a tray" do
-      expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
+      expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
       stub_request(:post, api_stock_url).
       with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
         headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -315,7 +315,7 @@ feature "Trays", type: :feature do
     end
 
    it "displays information about a successful association made" do
-      expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
+      expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
       stub_request(:post, api_stock_url).
       with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
         headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -336,7 +336,7 @@ feature "Trays", type: :feature do
    end
 
    it "accepts re-associating an item to the same tray" do
-      expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
+      expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
         with(headers: { "User-Agent"=>"Faraday v0.9.1" }).
@@ -373,7 +373,7 @@ feature "Trays", type: :feature do
    it "rejects associating an item to the wrong tray" do
       tray2 = FactoryGirl.create(:tray)
       item = FactoryGirl.create(:item, tray: tray2)
-      expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
+      expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
       stub_request(:post, api_stock_url).
         with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray2.barcode}"},
           headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
@@ -423,7 +423,7 @@ feature "Trays", type: :feature do
       click_button "Save"
       expect(current_path).to eq(show_tray_item_path(id: tray.id))
       items.each do |item|
-        expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
+        expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
         item_uri = api_item_url(item)
         stub_request(:post, item_uri).
           with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
@@ -525,7 +525,7 @@ feature "Trays", type: :feature do
       click_button "Save"
       expect(current_path).to eq(show_tray_item_path(id: tray.id))
       items.each do |item|
-        expect(GetItemFromBarcode).to receive(:call).with(@user.id, item.barcode).and_return(item).at_least :once
+        expect(GetItemFromBarcode).to receive(:call).with(barcode: item.barcode, user_id: @user.id).and_return(item).at_least :once
         item_uri = api_item_url(item)
         stub_request(:post, item_uri).
           with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},

--- a/spec/services/api_get_request_list_spec.rb
+++ b/spec/services/api_get_request_list_spec.rb
@@ -1,28 +1,24 @@
 require "rails_helper"
 
 RSpec.describe ApiGetRequestList do
-  let(:user_id) { 1 }
   context "self" do
     subject { described_class }
 
     describe "#call" do
-      subject { described_class.call(user_id) }
+      subject { described_class.call }
 
       it "retrieves data" do
         stub_api_active_requests
         expect(subject).to be_a_kind_of(ApiResponse)
         expect(subject.success?).to eq(true)
-        expect(subject.body).to be_a_kind_of(Array)
-        expect(subject.body.count).to eq(2)
-        expect(subject.body.first["trans"]).to eq("illiad_85132100")
+        expect(subject.body["requests"]).to be_a_kind_of(Array)
+        expect(subject.body["requests"].count).to eq(2)
+        expect(subject.body["requests"].first["transaction"]).to eq("illiad-85132100")
       end
 
-      it "does not raise an exception on API failure" do
+      it "raises an exception on API failure" do
         stub_api_active_requests(status_code: 500, body: {}.to_json)
-        expect(subject).to be_a_kind_of(ApiResponse)
-        expect(subject.error?).to eq(true)
-        expect(subject.body).to be_a_kind_of(Array)
-        expect(subject.body.count).to eq(0)
+        expect { subject }.to raise_error(described_class::ApiGetRequestsError)
       end
     end
   end

--- a/spec/services/associate_tray_with_item_barcode_spec.rb
+++ b/spec/services/associate_tray_with_item_barcode_spec.rb
@@ -24,38 +24,26 @@ RSpec.describe AssociateTrayWithItemBarcode do
     @user_id = 1 # Just fake having a user here
   end
 
-  after(:each) do
-    ActivityLog.all.each do |log|
-      log.destroy!
-    end
-    Item.all.each do |item|
-      item.destroy!
-    end
-    Tray.all.each do |tray|
-      tray.destroy!
-    end
-  end
-
   it "gets an item from the barcode" do
-    expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item)
+    expect(GetItemFromBarcode).to receive(:call).with(barcode: @item.barcode, user_id: @user.id).and_return(@item)
     subject
   end
 
   it "sets the item" do
-    expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item)
+    expect(GetItemFromBarcode).to receive(:call).with(barcode: @item.barcode, user_id: @user.id).and_return(@item)
     expect(@item).to receive("tray=").with(@tray)
     subject
   end
 
   it "returns the item when it is successful" do
-    expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item)
+    expect(GetItemFromBarcode).to receive(:call).with(barcode: @item.barcode, user_id: @user.id).and_return(@item)
     stub_request(:get, @item_uri). with(:headers => {'User-Agent'=>'Faraday v0.9.1'}). to_return{ |response| { :status => 200, :body => {"item_id" => "00110147500410", "barcode" => @item.barcode, "bib_id" => @item.bib_number, "sequence_number" => "00410", "admin_document_number" => "001101475", "call_number" => @item.call_number, "description" => @item.chron ,"title"=> @item.title, "author" => @item.author ,"publication" => "Cambridge, UK : Elsevier Science Publishers, c1991-", "edition" => "", "isbn_issn" =>@item.isbn_issn, "condition" => @item.conditions}.to_json, :headers => {} } }
     allow(@item).to receive(:save).and_return(true)
     expect(subject).to eq(@item)
   end
 
   it "returns false when it is unsuccessful" do
-    expect(GetItemFromBarcode).to receive(:call).with(@user.id, @item.barcode).and_return(@item)
+    expect(GetItemFromBarcode).to receive(:call).with(barcode: @item.barcode, user_id: @user.id).and_return(@item)
     allow(@item).to receive("save!").and_return(false)
     expect(subject).to be_falsey
   end

--- a/spec/services/get_item_from_barcode_spec.rb
+++ b/spec/services/get_item_from_barcode_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe GetItemFromBarcode do
-  subject { described_class.call(user.id, barcode) }
+  subject { described_class.call(barcode: barcode, user_id: user_id) }
 
+  let(:user_id) { user.id }
   let(:user) { instance_double(User, username: "bob", id: 1) }
   let(:barcode) { "123456789" }
 

--- a/spec/services/get_requests_spec.rb
+++ b/spec/services/get_requests_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe GetRequests do
+  subject { described_class.call }
+
+  it "creates requests" do
+    stub_api_active_requests
+    expect { subject }.to change { Request.count }.by(2)
+    expect(subject).to be_a_kind_of(Array)
+    expect(subject.count).to eq(2)
+    expect(subject.first.trans).to eq("illiad_85132100")
+  end
+end


### PR DESCRIPTION
This removes the API call every time the batches index page is visited.
The API call is moved to a cron job that runs every 15 minutes, and can be manually triggered by clicking a new "Refresh" button.

Also updated bootstrap-sass and sass-rails to fix the glyphicons.

I also refactored the GetItemFromBarcode calls to use named parameters, which I ended up not needing, but I didn't want to make the change and not commit it.