### PR TITLE
AIMS-251: Log SkippedItem

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -129,6 +129,8 @@ class BatchesController < ApplicationController
       @match.processed = "skipped"
       @match.save!
 
+      ActivityLogger.skip_item(item: @match.item, request: @match.request, user: current_user)
+
       redirect_to retrieve_batch_path
       return
     else

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -23,13 +23,11 @@ RSpec.describe BatchesController, type: :controller do
     end
   end
 
-
   describe "GET scan_bin" do
     it "logs a SkippedItem activity on Skip" do
       allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
       expect(ActivityLogger).to receive(:skip_item)
       get :scan_bin, commit: "Skip"
     end
-
   end
 end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -22,4 +22,14 @@ RSpec.describe BatchesController, type: :controller do
       get :item, commit: "Save", barcode: match.item.barcode
     end
   end
+
+
+  describe "GET scan_bin" do
+    it "logs a SkippedItem activity on Skip" do
+      allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
+      expect(ActivityLogger).to receive(:skip_item)
+      get :scan_bin, commit: "Skip"
+    end
+
+  end
 end


### PR DESCRIPTION
Why: There is more than one area where an item can be skipped. Missed this on the first PR.
How: Added a log call to the scan_bin method when the user skips the item.