### PR TITLE
AIMS-252: Log FilledRequest

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -12,6 +12,12 @@ class Request < ActiveRecord::Base
   belongs_to :filled_by_item, class_name: "Item", foreign_key: "item_id"
   belongs_to :filled_in_batch, class_name: "Batch", foreign_key: "batch_id"
 
+  enum status: { received: 0, completed: 1 }
+
+  def remaining_matches
+    matches.where("processed IS NULL OR processed NOT IN('skipped', 'completed')")
+  end
+
   def bin_type
     if self.source == "aleph"
       bt = "ALEPH-LOAN"

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -14,10 +14,6 @@ class Request < ActiveRecord::Base
 
   enum status: { received: 0, completed: 1 }
 
-  def remaining_matches
-    matches.where("processed IS NULL OR processed NOT IN('skipped', 'completed')")
-  end
-
   def bin_type
     if self.source == "aleph"
       bt = "ALEPH-LOAN"

--- a/app/queries/request_query.rb
+++ b/app/queries/request_query.rb
@@ -1,0 +1,11 @@
+class RequestQuery
+  attr_reader :relation
+
+  def initialize(relation = Request.all)
+    @relation = relation
+  end
+
+  def remaining_matches
+    relation.matches.where("processed IS NULL OR processed NOT IN('skipped', 'completed')")
+  end
+end

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -50,6 +50,10 @@ class ActivityLogger
     call(action: "DissociatedTrayAndShelf", user: user, tray: tray, shelf: shelf)
   end
 
+  def self.fill_request(user:, request:)
+    call(action: "FilledRequest", user: user, request: request)
+  end
+
   def self.remove_request(request:, user:)
     call(action: "RemovedRequest", request: request, user: user)
   end

--- a/app/services/complete_request.rb
+++ b/app/services/complete_request.rb
@@ -1,0 +1,19 @@
+class CompleteRequest
+  attr_reader :request, :user
+
+  def self.call(request:, user:)
+    new(request: request, user: user).complete!
+  end
+
+  def initialize(request:, user:)
+    @request = request
+    @user = user
+  end
+
+  def complete!
+    unless @request.completed?
+      @request.completed!
+      ActivityLogger.fill_request(user: user, request: request)
+    end
+  end
+end

--- a/app/services/process_match.rb
+++ b/app/services/process_match.rb
@@ -60,7 +60,8 @@ class ProcessMatch
   def complete_match
     @match.processed = "completed"
     @match.save!
-    if @match.request.remaining_matches.count == 0
+    request = RequestQuery.new(@match.request)
+    if request.remaining_matches.count == 0
       CompleteRequest.call(request: @match.request, user: user)
     end
   end

--- a/app/services/process_match.rb
+++ b/app/services/process_match.rb
@@ -14,6 +14,7 @@ class ProcessMatch
     ActiveRecord::Base.transaction do
       dissociate_bin
       scan_send
+      complete_match
     end
     notify_api
     true
@@ -54,5 +55,13 @@ class ProcessMatch
 
   def notify_api
     ApiScanSendJob.perform_later(match: match)
+  end
+
+  def complete_match
+    @match.processed = "completed"
+    @match.save!
+    if @match.request.remaining_matches.count == 0
+      CompleteRequest.call(request: @match.request, user: user)
+    end
   end
 end

--- a/app/services/process_match.rb
+++ b/app/services/process_match.rb
@@ -58,11 +58,11 @@ class ProcessMatch
   end
 
   def complete_match
-    @match.processed = "completed"
-    @match.save!
-    request = RequestQuery.new(@match.request)
-    if request.remaining_matches.count == 0
-      CompleteRequest.call(request: @match.request, user: user)
+    match.processed = "completed"
+    match.save!
+    request_query = RequestQuery.new(match.request)
+    if request_query.remaining_matches.count == 0
+      CompleteRequest.call(request: match.request, user: user)
     end
   end
 end

--- a/db/migrate/20150708181811_add_status_to_requests.rb
+++ b/db/migrate/20150708181811_add_status_to_requests.rb
@@ -1,0 +1,5 @@
+class AddStatusToRequests < ActiveRecord::Migration
+  def change
+    add_column :requests, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150706191210) do
+ActiveRecord::Schema.define(version: 20150708181811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 20150706191210) do
     t.string   "isbn_issn"
     t.string   "bib_number"
     t.string   "del_type",      default: "", null: false
+    t.integer  "status",        default: 0
   end
 
   add_index "requests", ["batch_id"], name: "index_requests_on_batch_id", using: :btree

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -31,32 +31,5 @@ RSpec.describe "Request" do
         end
       end
     end
-
-    context "#remaining_matches" do
-      it "does not exclude accepted matches" do
-        match = FactoryGirl.create(:match, request: request, processed: "accepted")
-        expect(request.remaining_matches.count).to eq(1)
-      end
-
-      it "does not exclude new matches (where processed is nil)" do
-        match = FactoryGirl.create(:match, request: request)
-        expect(request.remaining_matches.count).to eq(1)
-      end
-
-      it "excludes skipped matches" do
-        match = FactoryGirl.create(:match, request: request, processed: "skipped")
-        expect(request.remaining_matches.count).to eq(0)
-      end
-
-      it "excludes completed matches" do
-        match = FactoryGirl.create(:match, request: request, processed: "completed")
-        expect(request.remaining_matches.count).to eq(0)
-      end
-
-      it "does not exclude any matches in some other processed status" do
-        match = FactoryGirl.create(:match, request: request, processed: "some_new_thing")
-        expect(request.remaining_matches.count).to eq(1)
-      end
-    end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -31,5 +31,32 @@ RSpec.describe "Request" do
         end
       end
     end
+
+    context "#remaining_matches" do
+      it "does not exclude accepted matches" do
+        match = FactoryGirl.create(:match, request: request, processed: "accepted")
+        expect(request.remaining_matches.count).to eq(1)
+      end
+
+      it "does not exclude new matches (where processed is nil)" do
+        match = FactoryGirl.create(:match, request: request)
+        expect(request.remaining_matches.count).to eq(1)
+      end
+
+      it "excludes skipped matches" do
+        match = FactoryGirl.create(:match, request: request, processed: "skipped")
+        expect(request.remaining_matches.count).to eq(0)
+      end
+
+      it "excludes completed matches" do
+        match = FactoryGirl.create(:match, request: request, processed: "completed")
+        expect(request.remaining_matches.count).to eq(0)
+      end
+
+      it "does not exclude any matches in some other processed status" do
+        match = FactoryGirl.create(:match, request: request, processed: "some_new_thing")
+        expect(request.remaining_matches.count).to eq(1)
+      end
+    end
   end
 end

--- a/spec/queries/request_query_spec.rb
+++ b/spec/queries/request_query_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe RequestQuery do
+  let(:request) { FactoryGirl.create(:request) }
+  let(:subject) { RequestQuery.new(request) }
+
+  context "#remaining_matches" do
+    it "does not exclude accepted matches" do
+      match = FactoryGirl.create(:match, request: request, processed: "accepted")
+      expect(subject.remaining_matches.count).to eq(1)
+    end
+
+    it "does not exclude new matches (where processed is nil)" do
+      match = FactoryGirl.create(:match, request: request)
+      expect(subject.remaining_matches.count).to eq(1)
+    end
+
+    it "excludes skipped matches" do
+      match = FactoryGirl.create(:match, request: request, processed: "skipped")
+      expect(subject.remaining_matches.count).to eq(0)
+    end
+
+    it "excludes completed matches" do
+      match = FactoryGirl.create(:match, request: request, processed: "completed")
+      expect(subject.remaining_matches.count).to eq(0)
+    end
+
+    it "does not exclude any matches in some other processed status" do
+      match = FactoryGirl.create(:match, request: request, processed: "some_new_thing")
+      expect(subject.remaining_matches.count).to eq(1)
+    end
+  end
+end

--- a/spec/queries/request_query_spec.rb
+++ b/spec/queries/request_query_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe RequestQuery do
 
   context "#remaining_matches" do
     it "does not exclude accepted matches" do
-      match = FactoryGirl.create(:match, request: request, processed: "accepted")
+      FactoryGirl.create(:match, request: request, processed: "accepted")
       expect(subject.remaining_matches.count).to eq(1)
     end
 
     it "does not exclude new matches (where processed is nil)" do
-      match = FactoryGirl.create(:match, request: request)
+      FactoryGirl.create(:match, request: request)
       expect(subject.remaining_matches.count).to eq(1)
     end
 
     it "excludes skipped matches" do
-      match = FactoryGirl.create(:match, request: request, processed: "skipped")
+      FactoryGirl.create(:match, request: request, processed: "skipped")
       expect(subject.remaining_matches.count).to eq(0)
     end
 
     it "excludes completed matches" do
-      match = FactoryGirl.create(:match, request: request, processed: "completed")
+      FactoryGirl.create(:match, request: request, processed: "completed")
       expect(subject.remaining_matches.count).to eq(0)
     end
 
     it "does not exclude any matches in some other processed status" do
-      match = FactoryGirl.create(:match, request: request, processed: "some_new_thing")
+      FactoryGirl.create(:match, request: request, processed: "some_new_thing")
       expect(subject.remaining_matches.count).to eq(1)
     end
   end

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -132,6 +132,13 @@ RSpec.describe ActivityLogger do
     it_behaves_like "an activity log", "DissociatedTrayAndShelf"
   end
 
+  context "FilledRequest" do
+    let(:arguments) { { request: request, user: user } }
+    subject { described_class.fill_request(**arguments) }
+
+    it_behaves_like "an activity log", "FilledRequest"
+  end
+
   context "RemovedRequest" do
     let(:arguments) { { request: request, user: user } }
     subject { described_class.remove_request(**arguments) }

--- a/spec/services/complete_request_spec.rb
+++ b/spec/services/complete_request_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe CompleteRequest do
+  let(:user) { instance_double(User) }
+  let(:request) { instance_double(Request, completed!: true, completed?: false) }
+
+  it "changes the status of the request to completed" do
+    expect(request).to receive(:completed!)
+    allow(ActivityLogger).to receive(:fill_request)
+    described_class.call(request: request, user: user)
+  end
+
+  it "logs an activity" do
+    expect(ActivityLogger).to receive(:fill_request)
+    described_class.call(request: request, user: user)
+  end
+
+  it "does not log an activity if the request was already completed" do
+    allow(request).to receive(:completed?).and_return(true)
+    expect(ActivityLogger).not_to receive(:fill_request)
+    request.completed!
+    described_class.call(request: request, user: user)
+  end
+end

--- a/spec/services/process_match_spec.rb
+++ b/spec/services/process_match_spec.rb
@@ -40,4 +40,14 @@ RSpec.describe ProcessMatch do
     expect(ApiScanSendJob).to receive(:perform_later).with(match: match)
     subject
   end
+
+  it "completes the match" do
+    expect(match).to receive("processed=").with("completed")
+    subject
+  end
+
+  it "completes the request if it was the last match in that request" do
+    expect(CompleteRequest).to receive(:call)
+    subject
+  end
 end


### PR DESCRIPTION
Why: Need to log an activity when a request has been filled
How: Anytime a match gets processed, it will now change the status of the match to completed and additionally check to see if there are any remaining matches left for the associated request. If there are none, it will flag the request as completed and log a FilledRequest record to the ActivityLogs.