### PR TITLE
Compress to module function

### DIFF
--- a/app/services/is_bin_barcode.rb
+++ b/app/services/is_bin_barcode.rb
@@ -1,5 +1,5 @@
 module IsBinBarcode
-  PREFIX = '(BIN-)(ILL-LOAN|ILL-SCAN|ALEPH-LOAN)(-)'.freeze
+  PREFIX = "(BIN-)(ILL-LOAN|ILL-SCAN|ALEPH-LOAN)(-)".freeze
   def self.call(barcode)
     (barcode =~ /^#{PREFIX}(.*)/) ? true : false
   end

--- a/app/services/is_bin_barcode.rb
+++ b/app/services/is_bin_barcode.rb
@@ -1,18 +1,6 @@
-class IsBinBarcode
-  PREFIX = '(BIN-)(ILL-LOAN|ILL-SCAN|ALEPH-LOAN)(-)'
-
-  attr_reader :barcode
-
+module IsBinBarcode
+  PREFIX = '(BIN-)(ILL-LOAN|ILL-SCAN|ALEPH-LOAN)(-)'.freeze
   def self.call(barcode)
-    new(barcode).compare
+    (barcode =~ /^#{PREFIX}(.*)/) ? true : false
   end
-
-  def initialize(barcode)
-    @barcode = barcode
-  end
-
-  def compare
-    (barcode =~ /^#{PREFIX}(.*)/ ) ? true : false
-  end
-
 end

--- a/app/services/is_item_barcode.rb
+++ b/app/services/is_item_barcode.rb
@@ -1,16 +1,5 @@
-class IsItemBarcode
-  attr_reader :barcode
-
+module IsItemBarcode
   def self.call(barcode)
-    new(barcode).compare
-  end
-
-  def initialize(barcode)
-    @barcode = barcode
-  end
-
-  def compare
     !(IsTrayBarcode.call(barcode) || IsShelfBarcode.call(barcode) || IsBinBarcode.call(barcode))
   end
-
 end

--- a/app/services/is_object_item.rb
+++ b/app/services/is_object_item.rb
@@ -1,5 +1,6 @@
 module IsObjectItem
+  CLASS_NAME = "Item".freeze
   def self.call(item)
-    (item.class.to_s == "Item") ? true : false
+    (item.class.to_s == CLASS_NAME) ? true : false
   end
 end

--- a/app/services/is_object_item.rb
+++ b/app/services/is_object_item.rb
@@ -1,16 +1,5 @@
-class IsObjectItem
-  attr_reader :item
-
+module IsObjectItem
   def self.call(item)
-    new(item).compare
+    (item.class.to_s == "Item") ? true : false
   end
-
-  def initialize(item)
-    @item = item
-  end
-
-  def compare
-    (@item.class.to_s == "Item") ? true : false
-  end
-
 end

--- a/app/services/is_object_shelf.rb
+++ b/app/services/is_object_shelf.rb
@@ -1,5 +1,6 @@
 module IsObjectShelf
+  CLASS_NAME = "Shelf".freeze
   def self.call(shelf)
-    (shelf.class.to_s == "Shelf") ? true : false
+    (shelf.class.to_s == CLASS_NAME) ? true : false
   end
 end

--- a/app/services/is_object_shelf.rb
+++ b/app/services/is_object_shelf.rb
@@ -1,16 +1,5 @@
-class IsObjectShelf
-  attr_reader :shelf
-
+module IsObjectShelf
   def self.call(shelf)
-    new(shelf).compare
+    (shelf.class.to_s == "Shelf") ? true : false
   end
-
-  def initialize(shelf)
-    @shelf = shelf
-  end
-
-  def compare
-    (@shelf.class.to_s == "Shelf") ? true : false
-  end
-
 end

--- a/app/services/is_object_tray.rb
+++ b/app/services/is_object_tray.rb
@@ -1,16 +1,5 @@
-class IsObjectTray
-  attr_reader :tray
-
+module IsObjectTray
   def self.call(tray)
-    new(tray).compare
+    (tray.class.to_s == "Tray") ? true : false
   end
-
-  def initialize(tray)
-    @tray = tray
-  end
-
-  def compare
-    (@tray.class.to_s == "Tray") ? true : false
-  end
-
 end

--- a/app/services/is_object_tray.rb
+++ b/app/services/is_object_tray.rb
@@ -1,5 +1,6 @@
 module IsObjectTray
+  CLASS_NAME = "Tray".freeze
   def self.call(tray)
-    (tray.class.to_s == "Tray") ? true : false
+    (tray.class.to_s == CLASS_NAME) ? true : false
   end
 end

--- a/app/services/is_shelf_barcode.rb
+++ b/app/services/is_shelf_barcode.rb
@@ -1,18 +1,6 @@
-class IsShelfBarcode
-  PREFIX = 'SHELF-'
-
-  attr_reader :barcode
-
+module IsShelfBarcode
+  PREFIX = 'SHELF-'.freeze
   def self.call(barcode)
-    new(barcode).compare
-  end
-
-  def initialize(barcode)
-    @barcode = barcode
-  end
-
-  def compare
     (barcode =~ /^#{PREFIX}(.*)/ ) ? true : false
   end
-
 end

--- a/app/services/is_shelf_barcode.rb
+++ b/app/services/is_shelf_barcode.rb
@@ -1,5 +1,5 @@
 module IsShelfBarcode
-  PREFIX = 'SHELF-'.freeze
+  PREFIX = "SHELF-".freeze
   def self.call(barcode)
     (barcode =~ /^#{PREFIX}(.*)/ ) ? true : false
   end

--- a/app/services/is_tray_barcode.rb
+++ b/app/services/is_tray_barcode.rb
@@ -1,18 +1,6 @@
-class IsTrayBarcode
-  PREFIX = "(TRAY-)(([A-E][H,L])|(#{IsShelfBarcode::PREFIX}))"
-
-  attr_reader :barcode
-
+module IsTrayBarcode
+  PREFIX = "(TRAY-)(([A-E][H,L])|(#{IsShelfBarcode::PREFIX}))".freeze
   def self.call(barcode)
-    new(barcode).compare
-  end
-
-  def initialize(barcode)
-    @barcode = barcode
-  end
-
-  def compare
     (barcode =~ /^#{PREFIX}(.*)/ ) ? true : false
   end
-
 end

--- a/app/services/is_valid_thickness.rb
+++ b/app/services/is_valid_thickness.rb
@@ -1,16 +1,5 @@
-class IsValidThickness
-  attr_reader :thickness
-
+module IsValidThickness
   def self.call(thickness)
-    new(thickness).compare
-  end
-
-  def initialize(thickness)
-    @thickness = thickness
-  end
-
-  def compare
     thickness.to_s == thickness.to_i.to_s
   end
-
 end


### PR DESCRIPTION
@bcad4475c9b1e82f7d2dbbdd6a9e8cc182c50288

Freezing strings that are regularly reused

The strings were being instantiated and regularly collected via
GC. Prefer that they be instantiated once.

See for additional details http://josephyi.com/freeze/

@7258ee0699af9a6ceaf8c2466c7e9e653512546c

Prefer module functions instead of objects

The app/services/is_*.rb group of objects were instantiating an object
with each call to these "simple" service objects. This instantation had
two effects:

1) Another object that would need to be garbage collected
2) Additional steps to perform a "simple" comparison

This implementation preserves the outward facing interface of the Is*
objects, reduces memory consumption and GC, and still leaves room for
leveraging full objects if the logic gets more complicated.
