### PR TITLE
Asserting that '' is not a ItemBarcode

### DIFF
--- a/app/services/is_item_barcode.rb
+++ b/app/services/is_item_barcode.rb
@@ -1,5 +1,9 @@
 module IsItemBarcode
   def self.call(barcode)
-    !(IsTrayBarcode.call(barcode) || IsShelfBarcode.call(barcode) || IsBinBarcode.call(barcode))
+    return false unless barcode.present?
+    return false if IsTrayBarcode.call(barcode)
+    return false if IsShelfBarcode.call(barcode)
+    return false if IsBinBarcode.call(barcode)
+    true
   end
 end

--- a/spec/services/is_item_barcode_spec.rb
+++ b/spec/services/is_item_barcode_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe IsItemBarcode do
 
+  it "recognizes '' as an invalid barcode" do
+    expect(IsItemBarcode.call("")).to eq(false)
+  end
+
   it "recognizes '12345678901234' as a valid barcode" do
     barcode = '12345678901234'
     expect(IsItemBarcode.call(barcode)).to eq(true)


### PR DESCRIPTION
This is an interesting question, is '' an ItemBarcode?

If "" is a valid ItemBarCode then an ActiveRecord::InvalidRecord
exception is thrown on this line:

https://github.com/ndlib/annex-ims/blob/5d5e303e5fb6d4faa55157f593fc9feda78ff863/app/services/get_item_from_barcode.rb#L35

If "" is not a valid ItemBarCode then a StandardError exception is
thrown.

https://github.com/ndlib/annex-ims/blob/5d5e303e5fb6d4faa55157f593fc9feda78ff863/app/services/get_item_from_barcode.rb#L21

It is important to decide what is the correct answer as we the
handling of [AIMS-271](https://jira.library.nd.edu/browse/AIMS-271)
will vary