### PR TITLE
AIMS-255: Log BatchedRequest

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,6 +1,6 @@
 class Batch < ActiveRecord::Base
   has_many :matches
-  has_many :requests, through: :matches
+  has_many :requests, -> { uniq }, through: :matches
   has_many :items, through: :matches
   belongs_to :user
 

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -38,6 +38,10 @@ class ActivityLogger
     call(action: "AssociatedTrayAndShelf", user: user, tray: tray, shelf: shelf)
   end
 
+  def self.batch_request(request:, user:)
+    call(action: "BatchedRequest", user: user, request: request)
+  end
+
   def self.create_issue(issue:, item:)
     call(action: "CreatedIssue", issue: issue, item: item)
   end

--- a/app/services/build_batch.rb
+++ b/app/services/build_batch.rb
@@ -34,6 +34,10 @@ class BuildBatch
       match.save!
     end
 
+    batch.requests.each do |r|
+      ActivityLogger.batch_request(request: r, user: user)
+    end
+
     return batch
 
   end

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe ActivityLogger do
     it_behaves_like "an activity log", "AssociatedTrayAndShelf"
   end
 
+  context "BatchedRequest" do
+    let(:arguments) { { request: request, user: user } }
+    subject { described_class.batch_request(**arguments) }
+
+    it_behaves_like "an activity log", "BatchedRequest"
+  end
+
   context "CreatedIssue" do
     let(:arguments) { { issue: issue, item: item } }
     subject { described_class.create_issue(**arguments) }

--- a/spec/services/build_batch_spec.rb
+++ b/spec/services/build_batch_spec.rb
@@ -90,5 +90,16 @@ RSpec.describe BuildBatch, search: true do
       Sunspot.commit
     end
 
+    it "logs a BatchedRequest" do
+      test = ["#{request1.id}-#{item.id}"]
+      expect(ActivityLogger).to receive(:batch_request).with(request: request1, user: current_user)
+      described_class.call(test, current_user)
+    end
+
+    it "only logs one BatchedRequest log for a Request with multiple items" do
+      test = ["#{request1.id}-#{item.id}", "#{request1.id}-#{item2.id}"]
+      expect(ActivityLogger).to receive(:batch_request).with(request: request1, user: current_user).once
+      described_class.call(test, current_user)
+    end
   end
 end


### PR DESCRIPTION
Why: Need to track anytime a request is batched
How: Modified BuildBatch to log an activity for each unique request associated with the batch (since a batch can have multiple items for one request). To do this I had to modify the association between Batch and Request to only include unique values since it's through a 1->many relationship with Match