### PR TITLE
Removing OpenStruct usage

### DIFF
--- a/app/services/search_items.rb
+++ b/app/services/search_items.rb
@@ -19,10 +19,18 @@ class SearchItems
     @filter = filter
   end
 
+  class EmptyResults
+    def results
+      []
+    end
+
+    def total
+      0
+    end
+  end
+
   def search!
-    empty = OpenStruct.new
-    empty.results = []
-    empty.total = 0
+    empty = EmptyResults.new
 
     if filter[:criteria].blank? && filter[:conditions].blank? && filter[:date_type].blank?
       results = empty


### PR DESCRIPTION
Using OpenStruct invalidate's Ruby's method cache.

https://github.com/charliesome/charlie.bz/blob/master/posts/things-that-clear-rubys-method-cache.md