### PR TITLE
AIMS-270: UnstockedItem message when fullfilling a request

### DIFF
--- a/app/services/scan_item.rb
+++ b/app/services/scan_item.rb
@@ -14,7 +14,6 @@ class ScanItem
   def scan!
     validate_input!
 
-    UnstockItem.call(item, user) # Just in case it's not already unstocked, make sure.
     ActivityLogger.scan_item(item: item, request: request, user: user)
 
     item

--- a/app/services/unstock_item.rb
+++ b/app/services/unstock_item.rb
@@ -13,8 +13,11 @@ class UnstockItem
   def unstock!
     validate_input!
 
-    item.unstocked!
+    if item.unstocked?
+      return false
+    end
 
+    item.unstocked!
     if item.save!
       unless item.tray.nil?
         ActivityLogger.unstock_item(item: item, tray: item.tray, user: user)

--- a/spec/services/scan_item_spec.rb
+++ b/spec/services/scan_item_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe ScanItem do
     subject
   end
 
-  it "unstocks the item and logs the scan activity" do
-    expect(UnstockItem).to receive(:call).with(item, user)
+  it "logs the scan activity" do
     expect(ActivityLogger).to receive(:scan_item).with(item: item, request: request, user: user)
     subject
   end

--- a/spec/services/unstock_item_spec.rb
+++ b/spec/services/unstock_item_spec.rb
@@ -3,13 +3,15 @@ require 'rails_helper'
 RSpec.describe UnstockItem do
   subject { described_class.call(item, user)}
   let(:tray) { double(Tray, barcode: "TRAY-AH1234") }
-  let(:item) { instance_double(Item,
-                               unstocked?: false,
-                               save: true,
-                               "unstocked!" => nil,
-                               tray: tray,
-                               barcode: "1234",
-                               "save!" => true) }
+  let(:item) do
+    instance_double(Item,
+      unstocked?: false,
+      save: true,
+      "unstocked!" => nil,
+      tray: tray,
+      barcode: "1234",
+      "save!" => true)
+  end
   let(:user) { double(User, username: "bob", id: 1)}
 
   before(:each) do
@@ -28,13 +30,15 @@ RSpec.describe UnstockItem do
   end
 
   context "item already unstocked" do
-    let(:item) { instance_double(Item,
-                                 unstocked?: true,
-                                 save: true,
-                                 "unstocked!" => nil,
-                                 tray: tray,
-                                 barcode: "1234",
-                                 "save!" => true) }
+    let(:item) do
+      instance_double(Item,
+        unstocked?: true,
+        save: true,
+        "unstocked!" => nil,
+        tray: tray,
+        barcode: "1234",
+        "save!" => true)
+    end
 
     it "doesn't log the activity if it was already stocked" do
       expect(ActivityLogger).not_to receive(:unstock_item).with(item: item, tray: tray, user: user)

--- a/spec/services/unstock_item_spec.rb
+++ b/spec/services/unstock_item_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe UnstockItem do
   let(:tray) { double(Tray, barcode: "TRAY-AH1234") }
   let(:item) do
     instance_double(Item,
-      unstocked?: false,
-      save: true,
-      "unstocked!" => nil,
-      tray: tray,
-      barcode: "1234",
-      "save!" => true)
+                    unstocked?: false,
+                    save: true,
+                    "unstocked!" => nil,
+                    tray: tray,
+                    barcode: "1234",
+                    "save!" => true)
   end
   let(:user) { double(User, username: "bob", id: 1)}
 
@@ -32,12 +32,12 @@ RSpec.describe UnstockItem do
   context "item already unstocked" do
     let(:item) do
       instance_double(Item,
-        unstocked?: true,
-        save: true,
-        "unstocked!" => nil,
-        tray: tray,
-        barcode: "1234",
-        "save!" => true)
+                      unstocked?: true,
+                      save: true,
+                      "unstocked!" => nil,
+                      tray: tray,
+                      barcode: "1234",
+                      "save!" => true)
     end
 
     it "doesn't log the activity if it was already stocked" do

--- a/spec/services/unstock_item_spec.rb
+++ b/spec/services/unstock_item_spec.rb
@@ -3,7 +3,13 @@ require 'rails_helper'
 RSpec.describe UnstockItem do
   subject { described_class.call(item, user)}
   let(:tray) { double(Tray, barcode: "TRAY-AH1234") }
-  let(:item) { double(Item, "unstocked" => false, unstocked?: false, save: true, "unstocked!" => nil, tray: tray, barcode: "1234", "save!" => true)} # insert used methods
+  let(:item) { instance_double(Item,
+                               unstocked?: false,
+                               save: true,
+                               "unstocked!" => nil,
+                               tray: tray,
+                               barcode: "1234",
+                               "save!" => true) }
   let(:user) { double(User, username: "bob", id: 1)}
 
   before(:each) do
@@ -21,10 +27,19 @@ RSpec.describe UnstockItem do
     subject
   end
 
-  it "doesn't log the activity if it was already stocked" do
-    item = instance_double(Item, "unstocked" => false, unstocked?: false, save: true, "unstocked!" => nil, tray: tray, barcode: "1234", "save!" => true)
-    expect(ActivityLogger).not_to receive(:unstock_item).with(item: item, tray: tray, user: user)
-    described_class.call(item, user)
+  context "item already unstocked" do
+    let(:item) { instance_double(Item,
+                                 unstocked?: true,
+                                 save: true,
+                                 "unstocked!" => nil,
+                                 tray: tray,
+                                 barcode: "1234",
+                                 "save!" => true) }
+
+    it "doesn't log the activity if it was already stocked" do
+      expect(ActivityLogger).not_to receive(:unstock_item).with(item: item, tray: tray, user: user)
+      described_class.call(item, user)
+    end
   end
 
   it "returns the item when it is successful" do

--- a/spec/services/unstock_item_spec.rb
+++ b/spec/services/unstock_item_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe UnstockItem do
   subject { described_class.call(item, user)}
   let(:tray) { double(Tray, barcode: "TRAY-AH1234") }
-  let(:item) { double(Item, "unstocked" => false, save: true, "unstocked!" => nil, tray: tray, barcode: "1234", "save!" => true)} # insert used methods
+  let(:item) { double(Item, "unstocked" => false, unstocked?: false, save: true, "unstocked!" => nil, tray: tray, barcode: "1234", "save!" => true)} # insert used methods
   let(:user) { double(User, username: "bob", id: 1)}
 
   before(:each) do
@@ -19,6 +19,12 @@ RSpec.describe UnstockItem do
   it "logs the activity" do
     expect(ActivityLogger).to receive(:unstock_item).with(item: item, tray: tray, user: user)
     subject
+  end
+
+  it "doesn't log the activity if it was already stocked" do
+    item = instance_double(Item, "unstocked" => false, unstocked?: false, save: true, "unstocked!" => nil, tray: tray, barcode: "1234", "save!" => true)
+    expect(ActivityLogger).not_to receive(:unstock_item).with(item: item, tray: tray, user: user)
+    described_class.call(item, user)
   end
 
   it "returns the item when it is successful" do


### PR DESCRIPTION
Why: For item scans, we are getting an extra UnstockedItem message in the log when the request is completed.
How: ScanItem was calling an extra UnstockItem. At this point it should be unstocked, so I removed the call. Also changed UnstockItem to not perform the update to the object or log the call if the item was already unstocked.