### PR TITLE
AIMS-256: Log MatchedItem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,3 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever
-
-BUNDLED WITH
-   1.10.5

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -70,6 +70,10 @@ class ActivityLogger
     call(action: "FilledRequest", user: user, request: request)
   end
 
+  def self.match_item(item:, request:, user:)
+    call(action: "MatchedItem", item: item, request: request, user: user)
+  end
+
   def self.remove_request(request:, user:)
     call(action: "RemovedRequest", request: request, user: user)
   end

--- a/app/services/build_batch.rb
+++ b/app/services/build_batch.rb
@@ -32,6 +32,7 @@ class BuildBatch
       match.batch = batch
       match.request = request
       match.save!
+      ActivityLogger.match_item(item: item, request: request, user: user)
     end
 
     batch.requests.each do |r|

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -167,6 +167,13 @@ RSpec.describe ActivityLogger do
     it_behaves_like "an activity log", "FilledRequest"
   end
 
+  context "MatchedItem" do
+    let(:arguments) { { item: item, request: request, user: user } }
+    subject { described_class.match_item(**arguments) }
+
+    it_behaves_like "an activity log", "MatchedItem"
+  end
+
   context "RemovedRequest" do
     let(:arguments) { { request: request, user: user } }
     subject { described_class.remove_request(**arguments) }

--- a/spec/services/build_batch_spec.rb
+++ b/spec/services/build_batch_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe BuildBatch, search: true do
       Sunspot.commit
     end
 
+    it "logs a MatchedItem for each item in the batch" do
+      test = ["#{request1.id}-#{item.id}", "#{request1.id}-#{item2.id}"]
+      expect(ActivityLogger).to receive(:match_item).with(item: item, request: request1, user: current_user)
+      expect(ActivityLogger).to receive(:match_item).with(item: item2, request: request1, user: current_user)
+      described_class.call(test, current_user)
+    end
+
     it "logs a BatchedRequest" do
       test = ["#{request1.id}-#{item.id}"]
       expect(ActivityLogger).to receive(:batch_request).with(request: request1, user: current_user)


### PR DESCRIPTION
Why: Need to track when an item is matched
How: Added a match_item log method and changed BuildBatch to log a MatchedItem for each item added to matches.