### PR TITLE
AIMS-255: Log BatchedRequest

### DIFF
--- a/app/queries/request_query.rb
+++ b/app/queries/request_query.rb
@@ -10,6 +10,6 @@ class RequestQuery
   end
 
   def find_all_by_id(id_array:)
-    relation.where('requests.id IN (?)', id_array)
+    relation.where("requests.id IN (?)", id_array)
   end
 end

--- a/app/queries/request_query.rb
+++ b/app/queries/request_query.rb
@@ -8,4 +8,8 @@ class RequestQuery
   def remaining_matches
     relation.matches.where("processed IS NULL OR processed NOT IN('skipped', 'completed')")
   end
+
+  def find_all_by_id(id_array:)
+    relation.where('requests.id IN (?)', id_array)
+  end
 end

--- a/app/services/build_batch.rb
+++ b/app/services/build_batch.rb
@@ -20,23 +20,29 @@ class BuildBatch
       batch = user.batches.where(active: true).first
     end
 
-    batch_data.each do |data|
+    if batch_data.length > 0
+      new_request_ids = []
+      batch_data.each do |data|
 
-      lexed_data = data.split('-')
+        lexed_data = data.split('-')
 
-      request = Request.find(lexed_data[0])
-      item = Item.find(lexed_data[1])
+        request = Request.find(lexed_data[0])
+        item = Item.find(lexed_data[1])
 
-      match = Match.new
-      match.item = item
-      match.batch = batch
-      match.request = request
-      match.save!
-      ActivityLogger.match_item(item: item, request: request, user: user)
-    end
+        match = Match.new
+        match.item = item
+        match.batch = batch
+        match.request = request
+        match.save!
+        ActivityLogger.match_item(item: item, request: request, user: user)
 
-    batch.requests.each do |r|
-      ActivityLogger.batch_request(request: r, user: user)
+        new_request_ids.append request
+      end
+
+      new_requests = RequestQuery.new(batch.requests).find_all_by_id(id_array: new_request_ids)
+      new_requests.each do |r|
+        ActivityLogger.batch_request(request: r, user: user)
+      end
     end
 
     return batch

--- a/app/services/build_batch.rb
+++ b/app/services/build_batch.rb
@@ -24,7 +24,7 @@ class BuildBatch
       new_request_ids = []
       batch_data.each do |data|
 
-        lexed_data = data.split('-')
+        lexed_data = data.split("-")
 
         request = Request.find(lexed_data[0])
         item = Item.find(lexed_data[1])

--- a/spec/queries/request_query_spec.rb
+++ b/spec/queries/request_query_spec.rb
@@ -30,4 +30,9 @@ RSpec.describe RequestQuery do
       expect(subject.remaining_matches.count).to eq(1)
     end
   end
+
+  context "#find_all_by_id" do
+    it "returns request for each id"
+    it "does not return other requests"
+  end
 end

--- a/spec/queries/request_query_spec.rb
+++ b/spec/queries/request_query_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RequestQuery do
-  let(:request) { FactoryGirl.create(:request) }
+  let(:request) { FactoryGirl.create(:request, id: 1) }
   let(:subject) { RequestQuery.new(request) }
 
   context "#remaining_matches" do
@@ -32,7 +32,16 @@ RSpec.describe RequestQuery do
   end
 
   context "#find_all_by_id" do
-    it "returns request for each id"
-    it "does not return other requests"
+    let(:subject)  { RequestQuery.new }
+    let(:request2) { FactoryGirl.create(:request, id: 2) }
+    let(:request3) { FactoryGirl.create(:request, id: 3) }
+
+    it "returns request for each id" do
+      expect(subject.find_all_by_id(id_array: [1,2])).to include(request, request2)
+    end
+
+    it "does not return other requests" do
+      expect(subject.find_all_by_id(id_array: [1,2])).not_to include(request3)
+    end
   end
 end

--- a/spec/queries/request_query_spec.rb
+++ b/spec/queries/request_query_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe RequestQuery do
   end
 
   context "#find_all_by_id" do
-    let(:subject)  { RequestQuery.new }
+    let(:subject) { RequestQuery.new }
     let(:request2) { FactoryGirl.create(:request, id: 2) }
     let(:request3) { FactoryGirl.create(:request, id: 3) }
 
     it "returns request for each id" do
-      expect(subject.find_all_by_id(id_array: [1,2])).to include(request, request2)
+      expect(subject.find_all_by_id(id_array: [1, 2])).to include(request, request2)
     end
 
     it "does not return other requests" do
-      expect(subject.find_all_by_id(id_array: [1,2])).not_to include(request3)
+      expect(subject.find_all_by_id(id_array: [1, 2])).not_to include(request3)
     end
   end
 end

--- a/spec/services/build_batch_spec.rb
+++ b/spec/services/build_batch_spec.rb
@@ -108,5 +108,14 @@ RSpec.describe BuildBatch, search: true do
       expect(ActivityLogger).to receive(:batch_request).with(request: request1, user: current_user).once
       described_class.call(test, current_user)
     end
+
+    it "logs one BatchedRequest log for a new Request but doesn't log for Requests that were previously added to the batch" do
+      batch = FactoryGirl.create(:batch, user: current_user)
+      match1 = FactoryGirl.create(:match, batch: batch, request: request1)
+      test = ["#{request2.id}-#{item.id}", "#{request2.id}-#{item2.id}"]
+      expect(ActivityLogger).not_to receive(:batch_request).with(request: request1, user: current_user)
+      expect(ActivityLogger).to receive(:batch_request).with(request: request2, user: current_user)
+      described_class.call(test, current_user)
+    end
   end
 end

--- a/spec/services/build_batch_spec.rb
+++ b/spec/services/build_batch_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe BuildBatch, search: true do
 
     it "logs one BatchedRequest log for a new Request but doesn't log for Requests that were previously added to the batch" do
       batch = FactoryGirl.create(:batch, user: current_user)
-      match1 = FactoryGirl.create(:match, batch: batch, request: request1)
       test = ["#{request2.id}-#{item.id}", "#{request2.id}-#{item2.id}"]
       expect(ActivityLogger).not_to receive(:batch_request).with(request: request1, user: current_user)
       expect(ActivityLogger).to receive(:batch_request).with(request: request2, user: current_user)

--- a/spec/services/build_batch_spec.rb
+++ b/spec/services/build_batch_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe BuildBatch, search: true do
     end
 
     it "logs one BatchedRequest log for a new Request but doesn't log for Requests that were previously added to the batch" do
-      batch = FactoryGirl.create(:batch, user: current_user)
       test = ["#{request2.id}-#{item.id}", "#{request2.id}-#{item2.id}"]
       expect(ActivityLogger).not_to receive(:batch_request).with(request: request1, user: current_user)
       expect(ActivityLogger).to receive(:batch_request).with(request: request2, user: current_user)


### PR DESCRIPTION
Why: Was causing duplicate BatchedRequest records for Requests that were already added to the batch.
How: Added an additional filter to limit it to just the Request ids that were added as part of the current BuildBatch#build! action.