### PR TITLE
AIMS-234: Autofocus on Search within Items with Issues

### DIFF
--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -2,12 +2,6 @@
   %span
     = "There are no current outstanding issues."
 - else
-  = form_tag request.path, method: :get do
-    .field
-      = label_tag :barcode
-      = search_field_tag :barcode, params[:barcode], autofocus: "autofocus", placholder: 'A barcode'
-    .actions
-      = submit_tag 'Filter', class: 'btn btn-primary'
   %table.table.table-striped.condensed.datatable{"id" => "issues"}
     %thead
       %tr
@@ -31,4 +25,5 @@
   :javascript
       $(document).ready(function() {
         window.table = $('#issues').DataTable();
+        $('div.dataTables_filter input').focus();
       } );

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,3 +46,22 @@ end
     req_type: "doc_del",
   )
 end
+
+
+50.times do |i|
+  barcode = Item.order("RANDOM()").first.barcode
+  Issue.create!(
+    user_id: 1,
+    barcode: barcode,
+    issue_type: "not_found"
+  )
+end
+
+50.times do |i|
+  barcode = Item.order("RANDOM()").first.barcode
+  Issue.create!(
+    user_id: 1,
+    barcode: barcode,
+    issue_type: "not_for_annex"
+  )
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,8 +47,7 @@ end
   )
 end
 
-
-50.times do |i|
+50.times do
   barcode = Item.order("RANDOM()").first.barcode
   Issue.create!(
     user_id: 1,
@@ -57,7 +56,7 @@ end
   )
 end
 
-50.times do |i|
+50.times do
   barcode = Item.order("RANDOM()").first.barcode
   Issue.create!(
     user_id: 1,


### PR DESCRIPTION
Why: A new barcode search field was added, but we already had a search field that allowed searching by barcode. 
How: Removed the added field and gave focus to the existing Search input. Also added seed data for the issues table