### PR TITLE
Log the user when adding an issue

### DIFF
--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -46,8 +46,8 @@ class ActivityLogger
     call(action: "BatchedRequest", user: user, request: request)
   end
 
-  def self.create_issue(issue:, item:)
-    call(action: "CreatedIssue", issue: issue, item: item)
+  def self.create_issue(issue:, item:, user:)
+    call(action: "CreatedIssue", issue: issue, item: item, user: user)
   end
 
   def self.create_item(item:, user:)

--- a/app/services/add_issue.rb
+++ b/app/services/add_issue.rb
@@ -18,7 +18,7 @@ class AddIssue
       issue.user_id = user_id
       issue.save!
       if new_record
-        ActivityLogger.create_issue(item: item, issue: issue)
+        ActivityLogger.create_issue(item: item, issue: issue, user: user)
       end
       issue
     end
@@ -26,6 +26,10 @@ class AddIssue
 
 
   private
+
+  def user
+    @user ||= User.find(user_id)
+  end
 
   def barcode
     item.barcode

--- a/app/services/add_issue.rb
+++ b/app/services/add_issue.rb
@@ -1,12 +1,12 @@
 class AddIssue
-  attr_reader :user_id, :item, :issue_type
+  attr_reader :user, :item, :issue_type
 
-  def self.call(user_id:, item:, type:)
-    new(user_id: user_id, item: item, type: type).add
+  def self.call(user:, item:, type:)
+    new(user: user, item: item, type: type).add
   end
 
-  def initialize(user_id:, item:, type:)
-    @user_id = user_id
+  def initialize(user:, item:, type:)
+    @user = user
     @item = item
     @issue_type = type
   end
@@ -15,7 +15,7 @@ class AddIssue
     if valid?
       issue = Issue.find_or_initialize_by(barcode: barcode, issue_type: issue_type, resolved_at: nil)
       new_record = issue.new_record?
-      issue.user_id = user_id
+      issue.user = user
       issue.save!
       if new_record
         ActivityLogger.create_issue(item: item, issue: issue, user: user)
@@ -26,10 +26,6 @@ class AddIssue
 
 
   private
-
-  def user
-    @user ||= User.find(user_id)
-  end
 
   def barcode
     item.barcode

--- a/app/services/sync_item_metadata.rb
+++ b/app/services/sync_item_metadata.rb
@@ -70,7 +70,7 @@ class SyncItemMetadata
   def handle_error(error)
     save_metadata_status(error[:status])
     if error[:issue_type]
-      AddIssue.call(item: item, user_id: user_id, type: error[:issue_type])
+      AddIssue.call(item: item, user: user, type: error[:issue_type])
     end
     if error[:enqueue]
       process_in_background(error)

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe ActivityLogger do
   end
 
   context "CreatedIssue" do
-    let(:arguments) { { issue: issue, item: item } }
+    let(:arguments) { { issue: issue, item: item, user: user } }
     subject { described_class.create_issue(**arguments) }
 
     it_behaves_like "an activity log", "CreatedIssue"

--- a/spec/services/add_issue_spec.rb
+++ b/spec/services/add_issue_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AddIssue do
   end
 
   it "logs the issue creation" do
-    expect(ActivityLogger).to receive(:create_issue).with(item: item, issue: kind_of(Issue))
+    expect(ActivityLogger).to receive(:create_issue).with(item: item, issue: kind_of(Issue), user: user)
     subject
   end
 

--- a/spec/services/add_issue_spec.rb
+++ b/spec/services/add_issue_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AddIssue do
   let(:item) { FactoryGirl.create(:item) }
   let(:user) { FactoryGirl.create(:user) }
   let(:issue_type) { "not_found" }
-  subject { described_class.call(item: item, user_id: user.id, type: issue_type) }
+  subject { described_class.call(item: item, user: user, type: issue_type) }
 
   it "creates an issue with the correct type, barcode and user" do
     expect { subject }.to change { Issue.count }.from(0).to(1)
@@ -19,18 +19,18 @@ RSpec.describe AddIssue do
   end
 
   it "does not create a second issue for the same type" do
-    issue = described_class.call(item: item, user_id: user.id, type: issue_type)
+    issue = described_class.call(item: item, user: user, type: issue_type)
     expect(subject).to eq(issue)
   end
 
   it "creates a second issue for a different type" do
-    issue = described_class.call(item: item, user_id: user.id, type: "not_for_annex")
+    issue = described_class.call(item: item, user: user, type: "not_for_annex")
     expect(subject).to_not eq(issue)
   end
 
   it "creates a second for a different item" do
     other_item = FactoryGirl.create(:item)
-    issue = described_class.call(item: other_item, user_id: user.id, type: issue_type)
+    issue = described_class.call(item: other_item, user: user, type: issue_type)
     expect(subject).to_not eq(issue)
   end
 end

--- a/spec/services/sync_item_metadata_spec.rb
+++ b/spec/services/sync_item_metadata_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SyncItemMetadata do
 
       shared_examples "an issue logger" do |expected_issue_type|
         it "calls AddIssue with #{expected_issue_type}" do
-          expect(AddIssue).to receive(:call).with(item: item, user_id: user.id, type: expected_issue_type)
+          expect(AddIssue).to receive(:call).with(item: item, user: user, type: expected_issue_type)
           subject
         end
       end


### PR DESCRIPTION
The user was not getting logged when an issue was added.  This can help in identifying who scanned the barcode that has the issue.