### PR TITLE
AIMS-288 Fix sneakers restart while jobs are in the queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,6 @@ group :application do
   # For consuming the API for items
   gem "faraday"
   gem "faraday_middleware"
-  gem "excon"
-  gem "typhoeus"
   gem "multi_xml"
 
   # For item search

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,10 +153,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    ethon (0.7.2)
-      ffi (>= 1.3.0)
     eventmachine (1.0.7)
-    excon (0.43.0)
     execjs (2.5.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -169,7 +166,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.6)
+    ffi (1.9.10)
     formatador (0.2.5)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
@@ -383,8 +380,6 @@ GEM
     tins (1.5.4)
     turbolinks (2.5.2)
       coffee-rails
-    typhoeus (0.7.0)
-      ethon (>= 0.7.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.5.3)
@@ -428,7 +423,6 @@ DEPENDENCIES
   database_cleaner (~> 1.3)
   devise
   devise_cas_authenticatable
-  excon
   factory_girl_rails (~> 4.5)
   faker (~> 1.4)
   faraday
@@ -465,8 +459,10 @@ DEPENDENCIES
   sunspot_solr!
   thin
   turbolinks
-  typhoeus
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   webmock
   whenever
+
+BUNDLED WITH
+   1.10.5

--- a/app/services/api_get_request_list.rb
+++ b/app/services/api_get_request_list.rb
@@ -14,7 +14,7 @@ class ApiGetRequestList
     if response.success?
       response
     else
-      raise ApiGetRequestsError, "Error getting active requests from API. response: #{response.inspect}"
+      raise ApiGetRequestsError, "Error getting active requests from API. response: #{response.attributes}"
     end
   end
 

--- a/app/services/api_post_deliver_item.rb
+++ b/app/services/api_post_deliver_item.rb
@@ -16,7 +16,7 @@ class ApiPostDeliverItem
     if response.success?
       response
     else
-      raise ApiDeliverItemError, "Error sending #{delivery_type} request to API. params: #{params.inspect}, response: #{response.inspect}"
+      raise ApiDeliverItemError, "Error sending #{delivery_type} request to API. params: #{params}, response: #{response.attributes}"
     end
   end
 

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -16,7 +16,7 @@ class ApiPostStockItem
     if response.success?
       response
     else
-      raise ApiStockItemError, "Error sending stock request to API. params: #{params.inspect}, response: #{response.inspect}"
+      raise ApiStockItemError, "Error sending stock request to API. params: #{params}, response: #{response.attributes}"
     end
   end
 

--- a/app/services/external_rest_connection.rb
+++ b/app/services/external_rest_connection.rb
@@ -1,5 +1,3 @@
-require "typhoeus/adapters/faraday"
-
 # class for establishing a rest connection to an external source
 class ExternalRestConnection
   DEFAULT_CONNECTION_OPTIONS = {
@@ -77,18 +75,19 @@ class ExternalRestConnection
   end
 
   def setup_connection
-      faraday_instance.request :retry, request_retry_opts
-      faraday_instance.request :url_encoded
-      faraday_instance.response :json, content_type: /text\/plain/
-      faraday_instance.response :xml,  content_type: /\bxml$/
-      if cache_response?
-        faraday_instance.response :caching, file_cache, ignore_params: %w(access_token)
-      end
-      faraday_instance.adapter :typhoeus
+    faraday_instance.request :retry, request_retry_opts
+    faraday_instance.request :url_encoded
+    faraday_instance.response :json, content_type: /text\/plain/
+    faraday_instance.response :xml,  content_type: /\bxml$/
+    if cache_response?
+      faraday_instance.response :caching, file_cache, ignore_params: %w(access_token)
+    end
+    faraday_instance.adapter :net_http
   end
 
   def cache_response?
-    !(Rails.env.test? || Rails.env.development?)
+    # !(Rails.env.test? || Rails.env.development?)
+    false
   end
 
   def file_cache

--- a/app/services/external_rest_connection.rb
+++ b/app/services/external_rest_connection.rb
@@ -78,7 +78,7 @@ class ExternalRestConnection
     faraday_instance.request :retry, request_retry_opts
     faraday_instance.request :url_encoded
     faraday_instance.response :json, content_type: /text\/plain/
-    faraday_instance.response :xml,  content_type: /\bxml$/
+    faraday_instance.response :xml, content_type: /\bxml$/
     if cache_response?
       faraday_instance.response :caching, file_cache, ignore_params: %w(access_token)
     end
@@ -86,7 +86,6 @@ class ExternalRestConnection
   end
 
   def cache_response?
-    # !(Rails.env.test? || Rails.env.development?)
     false
   end
 

--- a/app/services/external_rest_connection.rb
+++ b/app/services/external_rest_connection.rb
@@ -2,87 +2,73 @@
 class ExternalRestConnection
   DEFAULT_CONNECTION_OPTIONS = {
     max_retries: Rails.configuration.settings.api_max_retries,
-    response_format: "json",
-  }
+    timeout: nil
+  }.freeze
 
-  attr_reader :base_url, :faraday_instance, :connection, :opts, :response
-  attr_accessor :request_body
+  attr_reader :base_url, :connection, :opts, :response
 
   def initialize(base_url: nil, connection_opts: {})
     @opts = DEFAULT_CONNECTION_OPTIONS.merge(connection_opts)
     @base_url = base_url
-    @connection = establish_connection
   end
 
   def max_retries
-    opts[:max_retries]
-  end
-
-  def response_format
-    opts[:response_format]
+    opts.fetch(:max_retries)
   end
 
   def timeout
-    opts[:timeout]
+    opts.fetch(:timeout)
   end
 
   # GET verb
   def get(path)
-    @response = connection.get do |req|
-      req.url path
-      if timeout
-        req.options.timeout = timeout
-      end
-    end
-    process_response
+    make_request(method: :get, path: path)
   end
 
   # PUT verb
-  def put(path, payload)
-    @response = connection.put do |req|
-      req.url path
-      req.body = payload
-      if timeout
-        req.options.timeout = timeout
-      end
-    end
-    process_response
+  def put(path, body)
+    make_request(method: :put, path: path, body: body)
   end
 
   # POST verb
-  def post(path, payload)
-    @response = connection.post do |req|
-      req.url path
-      req.body = payload
-      if timeout
-        req.options.timeout = timeout
-      end
-    end
-    process_response
+  def post(path, body)
+    make_request(method: :post, path: path, body: body)
   end
 
-  # custom error class
-  class Error < StandardError
+  def connection
+    @connection ||= establish_connection
   end
 
   private
 
+  def make_request(method:, path:, body: nil)
+    @response = connection.send(method) do |req|
+      req.url path
+      if body
+        req.body = body
+      end
+      if timeout
+        req.options.timeout = timeout
+      end
+    end
+    process_response
+  end
+
   def establish_connection
     Faraday.new(url: base_url) do |conn|
-      @faraday_instance = conn
-      setup_connection
+      setup_connection(conn)
     end
   end
 
-  def setup_connection
-    faraday_instance.request :retry, request_retry_opts
-    faraday_instance.request :url_encoded
-    faraday_instance.response :json, content_type: /text\/plain/
-    faraday_instance.response :xml, content_type: /\bxml$/
+  def setup_connection(new_connection)
+    new_connection.request :retry, request_retry_opts
+    new_connection.request :url_encoded
+    new_connection.response :json, content_type: /text\/plain/
+    new_connection.response :xml, content_type: /\bxml$/
     if cache_response?
-      faraday_instance.response :caching, file_cache, ignore_params: %w(access_token)
+      new_connection.response :caching, file_cache, ignore_params: %w(access_token)
     end
-    faraday_instance.adapter :net_http
+    new_connection.adapter :net_http
   end
 
   def cache_response?
@@ -90,7 +76,7 @@ class ExternalRestConnection
   end
 
   def file_cache
-    ActiveSupport::Cache::FileStore.new(
+    @file_cache ||= ActiveSupport::Cache::FileStore.new(
       File.join(rails_root, "/tmp", "cache"),
       namespace: "api_rest_data",
       expires_in: 240  # four minutes
@@ -118,17 +104,5 @@ class ExternalRestConnection
       result["results"] = {}
     end
     result
-  end
-
-  def expected_type?(type)
-    if response_format == "json"
-      type =~ /text\/plain/
-    else
-      type =~ /#{response_format}/
-    end
-  end
-
-  def response_content_type
-    response.headers["Content-Type"]
   end
 end

--- a/app/services/notify_error.rb
+++ b/app/services/notify_error.rb
@@ -1,16 +1,5 @@
-class NotifyError
-  attr_reader :exception, :args
-
+module NotifyError
   def self.call(exception:, args: {})
-    new(exception: exception, args: args).notify
-  end
-
-  def initialize(exception:, args: {})
-    @exception = exception
-    @args = args
-  end
-
-  def notify
     Airbrake.notify(exception, parameters: { args: args })
   end
 end

--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -127,10 +127,10 @@ namespace :sneakers do
         File.delete SneakersRakeHelper::pid_file
       end
     rescue SystemExit
-      # Don't log SystemExit errors
+      # Don't notify on SystemExit errors
       raise e
     rescue Interrupt
-      # Don't log Interrupt errors
+      # Don't notify on Interrupt errors
       raise e
     rescue Exception => e
       NotifyError.call(exception: e)
@@ -145,7 +145,7 @@ namespace :sneakers do
       SneakersRakeHelper::info "Stopping sneakers... (pid: #{pid})"
       if SneakersRakeHelper::process_running?(pid)
         Process.kill("TERM", pid)
-        30.times do
+        60.times do
           if SneakersRakeHelper::process_running?(pid)
             sleep(1)
           else

--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -10,99 +10,103 @@ namespace :sneakers do
   class SneakersWorkerError < StandardError
   end
 
-  def sneakers_logger
-    @sneakers_logger ||= Logger.new(STDOUT)
-  end
-
-  def sneakers_info(message)
-    sneakers_logger.info("[Sneakers Rake] #{message}")
-  end
-
-  def pid_file
-    Rails.root.join('tmp/pids/sneakers.pid')
-  end
-
-  def pid_file_exists?
-    File.exists?(pid_file)
-  end
-
-  def sneakers_pid
-    if pid_file_exists?
-      pid_value = File.read(pid_file).strip
-      if pid_value.present?
-        pid_value.to_i
+  class SneakersRakeHelper
+    class << self
+      def sneakers_logger
+        @sneakers_logger ||= Logger.new(STDOUT)
       end
-    end
-  end
 
-  def process_running?(pid)
-    begin
-      if pid
-        # Send a null signal to get the process status
-        Process.kill(0, pid)
-        true
-      else
-        false
+      def info(message)
+        sneakers_logger.info("[Sneakers Rake] #{message}")
       end
-    rescue Errno::ESRCH
-      false
-    end
-  end
 
-  # Start and stop a worker to make sure it is functional
-  def test_worker(worker_class)
-    worker = worker_class.new
-    begin
-      Timeout::timeout(60) do
-        worker.run
+      def pid_file
+        Rails.root.join('tmp/pids/sneakers.pid')
       end
-      true
-    rescue Timeout::Error
-      raise SneakersWorkerError, "Timed out while testing #{worker_class}"
-      false
-    ensure
-      worker.stop
+
+      def pid_file_exists?
+        File.exists?(pid_file)
+      end
+
+      def current_pid
+        if pid_file_exists?
+          pid_value = File.read(pid_file).strip
+          if pid_value.present?
+            pid_value.to_i
+          end
+        end
+      end
+
+      def process_running?(pid)
+        begin
+          if pid
+            # Send a null signal to get the process status
+            Process.kill(0, pid)
+            true
+          else
+            false
+          end
+        rescue Errno::ESRCH
+          false
+        end
+      end
+
+      # Start and stop a worker to make sure it is functional
+      def test_worker(worker_class)
+        worker = worker_class.new
+        begin
+          Timeout::timeout(60) do
+            worker.run
+          end
+          true
+        rescue Timeout::Error
+          raise SneakersWorkerError, "Timed out while testing #{worker_class}"
+          false
+        ensure
+          worker.stop
+        end
+      end
     end
   end
 
   desc "Ensures that sneakers is running"
   task :ensure_running do
-    sneakers_info "Ensuring sneakers is running"
+    SneakersRakeHelper::info "Ensuring sneakers is running"
     running = false
-    if pid_file_exists?
-      pid = sneakers_pid
-      if process_running?(pid)
+    if SneakersRakeHelper::pid_file_exists?
+      pid = SneakersRakeHelper::current_pid
+      if SneakersRakeHelper::process_running?(pid)
         running = true
       else
         timestamp = Time.now.strftime("%Y%m%d%H%M%S")
-        broken_name = "#{pid_file}.#{timestamp}"
-        File.rename(pid_file, broken_name)
-        sneakers_info "PID file exists, but sneakers is not running. Moving broken PID file: #{broken_name}"
+        broken_name = "#{SneakersRakeHelper::pid_file}.#{timestamp}"
+        File.rename(SneakersRakeHelper::pid_file, broken_name)
+        SneakersRakeHelper::info "PID file exists, but sneakers is not running. Moving broken PID file: #{broken_name}"
       end
     end
     if !running
       Rake::Task["sneakers:start"].invoke
     else
-      sneakers_info "Sneakers already running"
+      SneakersRakeHelper::info "Sneakers already running"
     end
   end
 
   desc "Start sneakers workers as a background process"
   task :start do |t, args|
-    sneakers_info "Starting sneakers in background"
+    SneakersRakeHelper::info "Starting sneakers in background"
     Process.fork do
       Rake::Task["sneakers:run"].invoke
     end
-    sneakers_info "Started sneakers"
+    SneakersRakeHelper::info "Started sneakers"
   end
 
   desc "Start the sneakers workers"
   task :run  => :environment do
     begin
-      if pid_file_exists?
-        raise SneakersPidFileExists, "Sneakers pid file already exists: #{pid_file}"
+      if SneakersRakeHelper::pid_file_exists?
+        raise SneakersPidFileExists, "Sneakers pid file already exists: #{SneakersRakeHelper::pid_file}"
       end
-      File.open(pid_file, 'w'){|f| f.puts Process.pid}
+      File.open(SneakersRakeHelper::pid_file, 'w') { |f| f.puts Process.pid }
       begin
         workers = []
         worker_classes = [
@@ -110,7 +114,7 @@ namespace :sneakers do
           ItemMetadataWorker,
         ]
         worker_classes.each do |worker_class|
-          test_worker(worker_class)
+          SneakersRakeHelper::test_worker(worker_class)
           worker_class.number_of_workers.times do
             workers << worker_class
           end
@@ -120,12 +124,14 @@ namespace :sneakers do
 
         runner.run
       ensure
-        File.delete pid_file
+        File.delete SneakersRakeHelper::pid_file
       end
     rescue SystemExit
-      # Ignore SystemExit errors
+      # Don't log SystemExit errors
+      raise e
     rescue Interrupt
-      # Ignore Interrupt errors
+      # Don't log Interrupt errors
+      raise e
     rescue Exception => e
       NotifyError.call(exception: e)
       raise e
@@ -134,13 +140,13 @@ namespace :sneakers do
 
   desc "Stop the sneakers background process"
   task :stop do
-    if pid = sneakers_pid
+    if pid = SneakersRakeHelper::current_pid
       stopped = false
-      sneakers_info "Stopping sneakers..."
-      if process_running?(pid)
-        Process.kill("INT", pid)
-        60.times do
-          if process_running?(pid)
+      SneakersRakeHelper::info "Stopping sneakers... (pid: #{pid})"
+      if SneakersRakeHelper::process_running?(pid)
+        Process.kill("TERM", pid)
+        30.times do
+          if SneakersRakeHelper::process_running?(pid)
             sleep(1)
           else
             stopped = true
@@ -151,18 +157,18 @@ namespace :sneakers do
         stopped = true
       end
       if stopped
-        sneakers_info "Stopped sneakers"
+        SneakersRakeHelper::info "Stopped sneakers"
       else
-        sneakers_info "INT sent to pid #{pid}, sneakers not stopped"
+        SneakersRakeHelper::info "TERM sent to pid #{pid}, sneakers not stopped"
       end
     else
-      sneakers_info "Sneakers not running"
+      SneakersRakeHelper::info "Sneakers not running"
     end
   end
 
   desc "Restart the sneakers background process"
   task :restart do
-    sneakers_info "Restarting sneakers"
+    SneakersRakeHelper::info "Restarting sneakers"
     Rake::Task["sneakers:stop"].invoke
     Rake::Task["sneakers:start"].invoke
   end

--- a/spec/services/external_rest_connection_spec.rb
+++ b/spec/services/external_rest_connection_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ExternalRestConnection do
   let(:base_url) { "http://example.com" }
-  let(:connection_opts) { { } }
+  let(:connection_opts) { {} }
   let(:request_path) { "/test" }
   let(:request_body) { { body: "body" } }
   let(:response_body) { { test: "test" }.to_json }

--- a/spec/services/external_rest_connection_spec.rb
+++ b/spec/services/external_rest_connection_spec.rb
@@ -1,0 +1,183 @@
+require "rails_helper"
+
+RSpec.describe ExternalRestConnection do
+  let(:base_url) { "http://example.com" }
+  let(:connection_opts) { { } }
+  let(:request_path) { "/test" }
+  let(:request_body) { { body: "body" } }
+  let(:response_body) { { test: "test" }.to_json }
+  let(:response_status) { 200 }
+  let(:expected_response_body) { JSON.parse(response_body) }
+  let(:expected_response) { { "status" => response_status, "results" => expected_response_body } }
+  let(:instance) { described_class.new(base_url: base_url, connection_opts: connection_opts) }
+
+  subject { instance }
+
+  describe "#timeout" do
+    it "defaults to nil" do
+      expect(subject.timeout).to be_nil
+    end
+
+    it "can be set to another value" do
+      connection_opts[:timeout] = 3
+      expect(subject.timeout).to eq(3)
+    end
+  end
+
+  describe "#max_retries" do
+    it "defaults to 2" do
+      expect(subject.max_retries).to eq(2)
+    end
+
+    it "can be set to another value" do
+      connection_opts[:max_retries] = 1
+      expect(subject.max_retries).to eq(1)
+    end
+  end
+
+  shared_examples "a request" do |method|
+    context "success" do
+      let(:response_status) { 200 }
+
+      before do
+        stub_request(method, File.join(base_url, request_path)).
+          to_return(status: response_status, body: response_body)
+      end
+
+      it "makes a #{method} request" do
+        expect(subject.send(method, *arguments)).to eq(expected_response)
+      end
+
+      it "uses the timeout value" do
+        connection_opts[:timeout] = 1
+        expect_any_instance_of(Faraday::RequestOptions).to receive(:timeout=).with(1)
+        subject.send(method, *arguments)
+      end
+    end
+
+    context "404 error" do
+      let(:response_status) { 404 }
+      let(:expected_response_body) { {} }
+
+      before do
+        stub_request(method, File.join(base_url, request_path)).
+          with(body: request_body).
+          to_return(status: response_status, body: response_body)
+      end
+
+      it "makes a #{method} request and returns an empty body" do
+        expect(subject.send(method, *arguments)).to eq(expected_response)
+      end
+    end
+
+    context "500 error" do
+      let(:response_status) { 500 }
+      let(:expected_response_body) { {} }
+
+      before do
+        stub_request(method, File.join(base_url, request_path)).
+          with(body: request_body).
+          to_return(status: response_status, body: response_body)
+      end
+
+      it "makes a #{method} request and returns an empty body" do
+        expect(subject.send(method, *arguments)).to eq(expected_response)
+      end
+    end
+  end
+
+  describe "#get" do
+    let(:request_body) { nil }
+    let(:arguments) { [request_path] }
+
+    it_behaves_like "a request", :get
+  end
+
+  describe "#post" do
+    let(:arguments) { [request_path, request_body] }
+
+    it_behaves_like "a request", :post
+  end
+
+  describe "#put" do
+    let(:arguments) { [request_path, request_body] }
+
+    it_behaves_like "a request", :put
+  end
+
+  describe "#connection" do
+    subject { instance.connection }
+
+    it "returns a connection" do
+      expect(subject).to be_a_kind_of(Faraday::Connection)
+    end
+
+    it "sets the adapter to Net::HTTP" do
+      expect_any_instance_of(Faraday::Connection).to receive(:adapter).with(:net_http)
+      subject
+    end
+
+    context "request" do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:request)
+      end
+
+      it "sets retry options" do
+        expect_any_instance_of(Faraday::Connection).to receive(:request).with(:retry, instance.send(:request_retry_opts))
+        subject
+      end
+
+      it "sets url_encoded" do
+        expect_any_instance_of(Faraday::Connection).to receive(:request).with(:url_encoded)
+        subject
+      end
+    end
+
+    context "response" do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:response)
+      end
+
+      it "sets json response" do
+        expect_any_instance_of(Faraday::Connection).to receive(:response).with(:json, content_type: /text\/plain/)
+        subject
+      end
+
+      it "sets xml response" do
+        expect_any_instance_of(Faraday::Connection).to receive(:response).with(:xml, content_type: /\bxml$/)
+        subject
+      end
+
+      it "does not set caching if cache_response? is false" do
+        expect(instance).to receive(:cache_response?).and_return(false)
+        expect_any_instance_of(Faraday::Connection).to_not receive(:response).with(:caching, anything, anything)
+        subject
+      end
+
+      it "sets caching if cache_response? is true" do
+        expect(instance).to receive(:cache_response?).and_return(true)
+        expect_any_instance_of(Faraday::Connection).to receive(:response).with(:caching, instance.send(:file_cache), ignore_params: %w(access_token))
+        subject
+      end
+    end
+  end
+
+  describe "#file_cache" do
+    it "returns a file cache object" do
+      expect(subject.send(:file_cache)).to be_a_kind_of(ActiveSupport::Cache::FileStore)
+    end
+  end
+
+  describe "#cache_response?" do
+    it "returns false" do
+      expect(subject.send(:cache_response?)).to eq(false)
+    end
+  end
+
+  describe "#request_retry_opts" do
+    it "returns retry options" do
+      expect(subject).to receive(:max_retries).and_return(100)
+      expect(subject.send(:request_retry_opts)).to eq(max: 100, interval: 0.05, interval_randomness: 1, backoff_factor: 2)
+    end
+  end
+end

--- a/spec/services/notify_error_spec.rb
+++ b/spec/services/notify_error_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe NotifyError do
+  let(:exception) { instance_double(StandardError) }
+  let(:args) { { test: "test" } }
+
+  subject { described_class.call(exception: exception, args: args) }
+
+  it "calls Airbrake#notify" do
+    expect(Airbrake).to receive(:notify).with(exception, parameters: { args: args })
+    subject
+  end
+end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,6 +1,6 @@
 module ApiHelper
   def api_url(action, params_hash = {})
-    base_url = ApiHandler.base_url || "http:/"
+    base_url = ApiHandler.base_url || "http://"
     path = ApiHandler.path(action)
     if params_hash.present?
       path += "&#{params_hash.to_param}"


### PR DESCRIPTION
Removing Typhoeus in favor of Net HTTP since Typhoeus was causing issues with process forking.

Move sneakers rake methods into helper class to avoid global method definitions
Only include the api response attributes in api errors to allow some grouping of error messages for each item
Disable any request caching to prevent receiving stale data from the API server
Use TERM instead of INT to kill running sneakers processes (INT could detach processes rather than stop them depending on the configuration)