### PR TITLE
Improve quality of error information sent via Airbrake

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,7 +8,7 @@ class ItemsController < ApplicationController
     begin
       @item = GetItemFromBarcode.call(barcode: params[:item][:barcode], user_id: current_user.id)
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to items_path
       return

--- a/app/controllers/shelves_controller.rb
+++ b/app/controllers/shelves_controller.rb
@@ -7,7 +7,7 @@ class ShelvesController < ApplicationController
     begin
       @shelf = GetShelfFromBarcode.call(params[:shelf][:barcode])
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to shelves_path
       return
@@ -69,7 +69,7 @@ class ShelvesController < ApplicationController
       redirect_to show_shelf_path(id: @shelf.id)
       return
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to show_shelf_path(id: @shelf.id)
       return

--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -8,7 +8,7 @@ class TraysController < ApplicationController
       @tray = GetTrayFromBarcode.call(params[:tray][:barcode])
       @size = TraySize.call(@tray.barcode)
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to trays_path
       return
@@ -43,7 +43,7 @@ class TraysController < ApplicationController
     begin
       AssociateTrayWithShelfBarcode.call(@tray, barcode, current_user)
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to show_tray_path(id: @tray.id)
       return
@@ -119,7 +119,7 @@ class TraysController < ApplicationController
       @tray = GetTrayFromBarcode.call(params[:tray][:barcode])
       @size = TraySize.call(@tray.barcode)
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to trays_items_path
       return
@@ -191,7 +191,7 @@ class TraysController < ApplicationController
       redirect_to show_tray_item_path(id: @tray.id)
       return
     rescue StandardError => e
-      NotifyError.call(exception: e)
+      notify_airbrake(e)
       flash[:error] = e.message
       redirect_to show_tray_item_path(id: @tray.id)
       return

--- a/app/services/api_handler.rb
+++ b/app/services/api_handler.rb
@@ -52,7 +52,7 @@ class ApiHandler
   private
 
   def handle_timeout_exception(exception)
-    NotifyError.call(exception: exception)
+    NotifyError.call(exception: exception, parameters: { action: action, params: params }, component: self.class.to_s, action: "transact!")
     ApiResponse.new(status_code: 599, body: {})
   end
 

--- a/app/services/notify_error.rb
+++ b/app/services/notify_error.rb
@@ -1,5 +1,17 @@
 module NotifyError
-  def self.call(exception:, args: {})
-    Airbrake.notify(exception, parameters: { args: args })
+  def self.call(exception:, parameters: {}, component: nil, action: nil)
+    Airbrake.notify(exception,
+                    component: component,
+                    action: action,
+                    parameters: parameters,
+                    cgi_data: environment_info)
+  end
+
+  private
+
+  def self.environment_info
+    ENV.reject do |k|
+      Airbrake.configuration.rake_environment_filters.include? k
+    end
   end
 end

--- a/app/workers/retry_worker.rb
+++ b/app/workers/retry_worker.rb
@@ -20,10 +20,12 @@ class RetryWorker < ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper
     self::WORKERS
   end
 
+  alias_method :original_work, :work
+
   def work(*args)
-    super(*args)
+    original_work(*args)
   rescue StandardError => e
-    NotifyError.call(exception: e, args: args)
+    NotifyError.call(exception: e, parameters: { args: args }, component: self.class.to_s, action: "work")
     logger.error e.message
     logger.error args
     logger.error e.backtrace.join("\n")

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,46 +1,80 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  # Code is not reloaded between requests.
+  config.cache_classes = true
 
-  # Do not eager load code on boot.
-  config.eager_load = false
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local = false
+  config.action_controller.perform_caching = true
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
+  # config.action_dispatch.rack_cache = true
 
-  # We need a default url for Devise.
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  # Disable Rails"s static asset server (Apache or NGINX will already do this).
+  config.serve_static_files = false
 
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
 
-  # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
-
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups.
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
@@ -48,5 +82,5 @@ end
 
 Devise.setup do |config|
   # CAS auth
-  config.cas_base_url = 'https://login.nd.edu/cas'
+  config.cas_base_url = "https://login.nd.edu/cas"
 end

--- a/lib/tasks/annex.rake
+++ b/lib/tasks/annex.rake
@@ -1,14 +1,10 @@
 namespace :annex do
   desc "Retrieves active requests from the API and creates or updates local request records"
   task get_active_requests: :environment do
-    begin
-      logger = Logger.new(STDOUT)
-      requests = GetRequests.call
-      message = I18n.t("requests.synchronized", count: requests.count)
-      logger.info("[annex:get_active_requests] #{message}")
-    rescue StandardError => e
-      NotifyError.call(exception: e)
-      raise e
-    end
+    Airbrake.configuration.rescue_rake_exceptions = true
+    logger = Logger.new(STDOUT)
+    requests = GetRequests.call
+    message = I18n.t("requests.synchronized", count: requests.count)
+    logger.info("[annex:get_active_requests] #{message}")
   end
 end

--- a/spec/controllers/trays_controller_spec.rb
+++ b/spec/controllers/trays_controller_spec.rb
@@ -14,4 +14,17 @@ RSpec.describe TraysController, :type => :controller do
     end
   end
 
+  describe "POST scan" do
+    it "redirects" do
+      post :scan, tray: { barcode: "TRAY-AL123" }
+      expect(response).to be_redirect
+      expect(response.location).to match(/trays\/shelves\/\d+/)
+    end
+
+    it "calls notify_airbrake on error and redirects to the trays path" do
+      expect(controller).to receive(:notify_airbrake).with(kind_of(RuntimeError))
+      post :scan, tray: { barcode: "12345" }
+      expect(response).to redirect_to(trays_path)
+    end
+  end
 end

--- a/spec/services/notify_error_spec.rb
+++ b/spec/services/notify_error_spec.rb
@@ -2,12 +2,36 @@ require "rails_helper"
 
 RSpec.describe NotifyError do
   let(:exception) { instance_double(StandardError) }
-  let(:args) { { test: "test" } }
+  let(:parameters) { { test: "test" } }
+  let(:component) { "component" }
+  let(:action) { "action" }
+  let(:expected_environment) { { environment: "environment" } }
 
-  subject { described_class.call(exception: exception, args: args) }
+  subject { described_class.call(exception: exception, parameters: parameters, component: component, action: action) }
+
+  before do
+    allow(described_class).to receive(:environment_info).and_return(expected_environment)
+  end
 
   it "calls Airbrake#notify" do
-    expect(Airbrake).to receive(:notify).with(exception, parameters: { args: args })
+    expect(Airbrake).to receive(:notify).with(exception, component: component, action: action, parameters: parameters, cgi_data: expected_environment)
     subject
+  end
+
+  context "environment_info" do
+    subject { described_class.environment_info }
+
+    before do
+      allow(described_class).to receive(:environment_info).and_call_original
+    end
+
+    it "filters the environment data" do
+      allow(Airbrake.configuration).to receive(:rake_environment_filters).and_return(["REJECT_KEY"])
+      ENV["REJECT_KEY"] = "rejected"
+      unfiltered_values = ENV.reject { false }
+      filtered_values = ENV.reject { |k| k == "REJECT_KEY" }
+      expect(subject).to_not eq(unfiltered_values)
+      expect(subject).to eq(filtered_values)
+    end
   end
 end


### PR DESCRIPTION
This includes a number of changes to notifications sent through Airbrake.

1.Calls using our NotifyError service don't have access to the controller params and environment.  Using the notify_airbrake method provided by the Airbrake gem allows us to send more information.
2. I updated the rake tasks to make use of Airbrake's internal handler for errors in rake tasks
3. I enhanced the NotifyError service to send more information (similar to how Airbrake handle's rake tasks)
4. Improved a handful of related specs
5. Updated the staging environment to match prod/pprd configurations so it will send error messages.