### PR TITLE
AIMS-295 Add message body for 422 return codes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,5 +464,5 @@ DEPENDENCIES
   webmock
   whenever
 
-  BUNDLED WITH
-     1.10.5
+BUNDLED WITH
+   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,3 +463,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever
+
+  BUNDLED WITH
+     1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,6 +463,3 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever
-
-BUNDLED WITH
-   1.10.5

--- a/app/services/api_handler.rb
+++ b/app/services/api_handler.rb
@@ -42,7 +42,7 @@ class ApiHandler
 
   def transact!
     raw_response = raw_transact!
-    ApiResponse.new(status_code: raw_response["status"], body: raw_response["results"])
+    ApiResponse.new(status_code: raw_response[:status], body: raw_response[:results])
   rescue Timeout::Error => e
     handle_timeout_exception(e)
   rescue Faraday::TimeoutError => e

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -29,5 +29,4 @@ class ApiPostStockItem
       tray_code: item.tray.barcode
     }
   end
-
 end

--- a/app/services/external_rest_connection.rb
+++ b/app/services/external_rest_connection.rb
@@ -79,8 +79,7 @@ class ExternalRestConnection
     @file_cache ||= ActiveSupport::Cache::FileStore.new(
       File.join(rails_root, "/tmp", "cache"),
       namespace: "api_rest_data",
-      expires_in: 240  # four minutes
-    )
+      expires_in: 240)
   end
 
   def rails_root
@@ -97,8 +96,10 @@ class ExternalRestConnection
   end
 
   def process_response
-    result = {"status" => response.status}
+    result = { status: response.status }
     if response.status == 200
+      result["results"] = JSON.parse(response.body)
+    elsif response.status == 422
       result["results"] = JSON.parse(response.body)
     else
       result["results"] = {}

--- a/app/services/external_rest_connection.rb
+++ b/app/services/external_rest_connection.rb
@@ -98,11 +98,11 @@ class ExternalRestConnection
   def process_response
     result = { status: response.status }
     if response.status == 200
-      result["results"] = JSON.parse(response.body)
+      result[:results] = JSON.parse(response.body)
     elsif response.status == 422
-      result["results"] = JSON.parse(response.body)
+      result[:results] = JSON.parse(response.body)
     else
-      result["results"] = {}
+      result[:results] = {}
     end
     result
   end

--- a/spec/services/api_handler_spec.rb
+++ b/spec/services/api_handler_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe ApiHandler do
   let(:response_status) { 200 }
   let(:raw_response) do
     {
-      "status" => response_status,
-      "results" => { "test" => "test" }
+      status: response_status,
+      results: { "test" => "test" }
     }
   end
 

--- a/spec/services/external_rest_connection_spec.rb
+++ b/spec/services/external_rest_connection_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe ExternalRestConnection do
         expect(subject.send(method, *arguments)).to eq(expected_response)
       end
     end
+
+    context "422 error" do
+      let(:response_status) { 422 }
+
+      before do
+        stub_request(method, File.join(base_url, request_path)).
+          with(body: request_body).
+          to_return(status: response_status, body: response_body)
+      end
+
+      it "makes a #{method} request and returns body" do
+        expect(subject.send(method, *arguments)).to eq(expected_response)
+      end
+    end
   end
 
   describe "#get" do

--- a/spec/services/external_rest_connection_spec.rb
+++ b/spec/services/external_rest_connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ExternalRestConnection do
   let(:response_body) { { test: "test" }.to_json }
   let(:response_status) { 200 }
   let(:expected_response_body) { JSON.parse(response_body) }
-  let(:expected_response) { { :status => response_status, :results => expected_response_body } }
+  let(:expected_response) { { status: response_status, results: expected_response_body } }
   let(:instance) { described_class.new(base_url: base_url, connection_opts: connection_opts) }
 
   subject { instance }

--- a/spec/services/external_rest_connection_spec.rb
+++ b/spec/services/external_rest_connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ExternalRestConnection do
   let(:response_body) { { test: "test" }.to_json }
   let(:response_status) { 200 }
   let(:expected_response_body) { JSON.parse(response_body) }
-  let(:expected_response) { { "status" => response_status, "results" => expected_response_body } }
+  let(:expected_response) { { :status => response_status, :results => expected_response_body } }
   let(:instance) { described_class.new(base_url: base_url, connection_opts: connection_opts) }
 
   subject { instance }


### PR DESCRIPTION
What: Added return message body for 422 return codes
Why: So that we can see the error message returned from Aleph in the activity log
How: Modified the external rest class so that it includes message bodies for that return code