### PR TITLE
AIMS-295:  Add 422 issue

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,7 +3,6 @@ class Issue < ActiveRecord::Base
 
   validates :barcode, presence: true
   validates :issue_type, presence: true, inclusion: ISSUE_TYPES
-  validates :user_id, presence: true
 
   belongs_to :user
   belongs_to :resolver, class_name: "User"

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,5 @@
 class Issue < ActiveRecord::Base
-  ISSUE_TYPES = ["not_found", "not_for_annex"]
+  ISSUE_TYPES = ["not_found", "not_for_annex", "aleph_error"]
 
   validates :barcode, presence: true
   validates :issue_type, presence: true, inclusion: ISSUE_TYPES

--- a/app/services/add_issue.rb
+++ b/app/services/add_issue.rb
@@ -1,19 +1,20 @@
 class AddIssue
-  attr_reader :user, :item, :issue_type
+  attr_reader :user, :item, :issue_type, :message
 
-  def self.call(user:, item:, type:)
-    new(user: user, item: item, type: type).add
+  def self.call(user:, item:, type:, message: nil)
+    new(user: user, item: item, type: type, message: message).add
   end
 
-  def initialize(user:, item:, type:)
+  def initialize(user:, item:, type:, message:)
     @user = user
     @item = item
     @issue_type = type
+    @message = message
   end
 
   def add
     if valid?
-      issue = Issue.find_or_initialize_by(barcode: barcode, issue_type: issue_type, resolved_at: nil)
+      issue = Issue.find_or_initialize_by(barcode: barcode, issue_type: issue_type, message: message, resolved_at: nil)
       new_record = issue.new_record?
       issue.user = user
       issue.save!

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -24,7 +24,7 @@ class ApiPostStockItem
 
   def handle_error(response)
     if response.status_code == 422
-      AddIssue.call(item: item, user: nil, type: "aleph_error")
+      AddIssue.call(item: item, user: nil, type: "aleph_error", message: response.body)
     end
     raise ApiStockItemError, "Error sending stock request to API. params: #{params}, response: #{response.attributes}"
   end

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -16,11 +16,18 @@ class ApiPostStockItem
     if response.success?
       response
     else
-      raise ApiStockItemError, "Error sending stock request to API. params: #{params}, response: #{response.attributes}"
+      handle_error(response)
     end
   end
 
   private
+
+  def handle_error(response)
+    if response.status_code == 422
+      AddIssue.call(item: item, user: nil, type: "aleph_error")
+    end
+    raise ApiStockItemError, "Error sending stock request to API. params: #{params}, response: #{response.attributes}"
+  end
 
   def params
     {

--- a/app/services/api_post_stock_item.rb
+++ b/app/services/api_post_stock_item.rb
@@ -24,7 +24,7 @@ class ApiPostStockItem
 
   def handle_error(response)
     if response.status_code == 422
-      AddIssue.call(item: item, user: nil, type: "aleph_error", message: response.body)
+      AddIssue.call(item: item, user: nil, type: "aleph_error", message: response.body["message"])
     end
     raise ApiStockItemError, "Error sending stock request to API. params: #{params}, response: #{response.attributes}"
   end

--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -6,6 +6,7 @@
     %thead
       %tr
         %th= 'Barcode'
+        %th= 'Type'
         %th= 'Message'
         %th= 'Created'
         %th= 'User'
@@ -15,8 +16,9 @@
         %tr
           %td= link_to issue.barcode, item_detail_path(issue.barcode)
           %td= t "issues.issue_type.#{issue.issue_type}"
+          %td= issue.message
           %td= issue.created_at.strftime("%m-%d-%Y %I:%M%p")
-          %td= issue.user.username
+          %td= issue.user ? issue.user.username : "system"
           %td
             = form_tag resolve_issue_path do |f|
               = hidden_field_tag :issue_id, issue.id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
       error: "Error loading metadata, will retry automatically"
       not_for_annex: "Item not flagged for annex"
       not_found: "Barcode not found"
+      aleph_error: "Aleph processing error"
       pending: "Metadata sync pending"
     set: "%{ordinal_number} of %{total_number}"
   issues:

--- a/db/migrate/20150728200747_drop_issue_user_fk_add_message.rb
+++ b/db/migrate/20150728200747_drop_issue_user_fk_add_message.rb
@@ -1,0 +1,7 @@
+class DropIssueUserFkAddMessage < ActiveRecord::Migration
+  def change
+    remove_foreign_key :issues, column: :user_id
+    add_column :issues, :message, :string
+    change_column_null :issues, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150710142409) do
+ActiveRecord::Schema.define(version: 20150728200747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,13 +49,14 @@ ActiveRecord::Schema.define(version: 20150710142409) do
   add_index "bins", ["barcode"], name: "index_bins_on_barcode", unique: true, using: :btree
 
   create_table "issues", force: :cascade do |t|
-    t.integer  "user_id",     null: false
+    t.integer  "user_id"
     t.string   "barcode",     null: false
     t.integer  "resolver_id"
     t.datetime "resolved_at"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.string   "issue_type",  null: false
+    t.string   "message"
   end
 
   add_index "issues", ["resolver_id"], name: "index_issues_on_resolver_id", using: :btree
@@ -161,7 +162,6 @@ ActiveRecord::Schema.define(version: 20150710142409) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   add_foreign_key "batches", "users"
-  add_foreign_key "issues", "users"
   add_foreign_key "issues", "users", column: "resolver_id"
   add_foreign_key "items", "bins"
   add_foreign_key "items", "trays"

--- a/spec/services/add_issue_spec.rb
+++ b/spec/services/add_issue_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe AddIssue do
   let(:item) { FactoryGirl.create(:item) }
   let(:user) { FactoryGirl.create(:user) }
   let(:issue_type) { "not_found" }
-  subject { described_class.call(item: item, user: user, type: issue_type) }
+  let(:message) { "item was not found" }
+  subject { described_class.call(item: item, user: user, type: issue_type, message: message) }
 
-  it "creates an issue with the correct type, barcode and user" do
+  it "creates an issue with the correct type, barcode, message and user" do
     expect { subject }.to change { Issue.count }.from(0).to(1)
     expect(subject.user).to eq(user)
     expect(subject.issue_type).to eq(issue_type)
     expect(subject.barcode).to eq(item.barcode)
+    expect(subject.message).to eq(message)
   end
 
   it "logs the issue creation" do
@@ -19,7 +21,7 @@ RSpec.describe AddIssue do
   end
 
   it "does not create a second issue for the same type" do
-    issue = described_class.call(item: item, user: user, type: issue_type)
+    issue = described_class.call(item: item, user: user, type: issue_type, message: message)
     expect(subject).to eq(issue)
   end
 

--- a/spec/services/api_post_stock_item_spec.rb
+++ b/spec/services/api_post_stock_item_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe ApiPostStockItem do
         stub_api_stock_item(item: item, status_code: 500, body: {}.to_json)
         expect { subject }.to raise_error(described_class::ApiStockItemError)
       end
+
+      it "raises an exception and adds an issue on unprocessable entities" do
+        stub_api_stock_item(
+          item: item,
+          status_code: 422,
+          body: { "status" => "error", "message" => "this is the error" }.to_json
+        )
+        expect(AddIssue).to receive(:call).with(hash_including(item: item, type: "aleph_error", message: "this is the error"))
+        expect { subject }.to raise_error(described_class::ApiStockItemError)
+      end
     end
   end
 end


### PR DESCRIPTION
Why: Whenever we get a 422 back from the api when stocking an item, it means that aleph encountered an error with processing/updating the item. This needs to bubble up to the user as an issue so that someone can manually address the problem in Aleph.
How: Created a new aleph_error type in issues and started creating an issue when we receive a 422 during ApiPostStockItem. The api will now respond with the error message that it received from aleph, so added this to issues table/form. We also decided to drop the fk constraint and user_id validation on issues. Issues previously required an associated user, but background operations do not have a user. 