### PR TITLE
AIMS-297 Add more info to item detail page

### DIFF
--- a/app/decorators/item_with_issue.rb
+++ b/app/decorators/item_with_issue.rb
@@ -1,0 +1,4 @@
+module ItemWithIssue
+  def status
+  end
+end

--- a/app/queries/activity_log_query.rb
+++ b/app/queries/activity_log_query.rb
@@ -3,13 +3,26 @@ module ActivityLogQuery
 
   def shelf_history(shelf)
     for_shelf(shelf).
-      where(action: ["AssociatedTrayAndShelf", "DissociatedTrayAndShelf", "ShelvedTray", "UnshelvedTray"]).
+      where(action: [
+        "AssociatedTrayAndShelf",
+        "DissociatedTrayAndShelf",
+        "ShelvedTray",
+        "UnshelvedTray"]).
       order(action_timestamp: :desc)
   end
 
   def item_history(item)
     for_item(item).
-      where(action: ["StockedItem", "UnstockedItem", "CreatedItem", "DestroyedItem"]).
+      where(action: [
+        "AcceptedItem",
+        "StockedItem",
+        "UnstockedItem",
+        "CreatedItem",
+        "CreatedIssue",
+        "DestroyedItem",
+        "DissociatedItemAndTray",
+        "DissociatedItemAndBin",
+        "ShippedItem"]).
       order(action_timestamp: :desc)
   end
 

--- a/app/queries/issues_for_item_query.rb
+++ b/app/queries/issues_for_item_query.rb
@@ -1,0 +1,12 @@
+module IssuesForItemQuery
+  module_function
+
+  def call(barcode:, relation: default_relation)
+    relation.where(barcode: barcode)
+  end
+
+  def default_relation
+    Issue.all
+  end
+  private_class_method :default_relation
+end

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -159,7 +159,7 @@ class ActivityLogger
       data: data,
       username: username,
       user_id: user_id,
-      action_timestamp: Time.now,
+      action_timestamp: Time.zone.now,
     )
   end
 

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -159,7 +159,7 @@ class ActivityLogger
       data: data,
       username: username,
       user_id: user_id,
-      action_timestamp: Time.zone.now,
+      action_timestamp: Time.now,
     )
   end
 

--- a/spec/queries/issues_for_item_query_spec.rb
+++ b/spec/queries/issues_for_item_query_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe IssuesForItemQuery do
+  let(:item) { FactoryGirl.build(:item) }
+  let(:item2) { FactoryGirl.build(:item) }
+  let(:item3) { FactoryGirl.build(:item) }
+  let!(:issue1) { FactoryGirl.create(:issue, issue_type: "not_for_annex", barcode: item.barcode) }
+  let!(:issue2) { FactoryGirl.create(:issue, issue_type: "not_for_annex", barcode: item3.barcode) }
+  let!(:issue3) { FactoryGirl.create(:issue, issue_type: "not_found", barcode: item3.barcode) }
+  let(:subject) { described_class }
+
+  context "no issues for item" do
+    it "does not return any issues" do
+      expect(subject.call(barcode: item2.barcode).count).to eq 0
+    end
+  end
+
+  context "issues for item" do
+    it "returns issue" do
+      expect(subject.call(barcode: item.barcode).count).to eq 1
+    end
+
+    it "returns all issues when multiple issues present" do
+      expect(subject.call(barcode: item3.barcode).count).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
What: Aaron requested that we indicate when an item was dissociated from a tray on the item detail page, which I did and also added several other transitions to the list.
How:  Added several actions to the item_history method and cleaned up the activity_log_query.rb file a bit.