### PR TITLE
AIMS-303: Activity indexing

### DIFF
--- a/app/queries/activity_log_query.rb
+++ b/app/queries/activity_log_query.rb
@@ -38,12 +38,12 @@ module ActivityLogQuery
 
   def for_item(item)
     relation.
-      where("data -> 'item' ->> 'barcode' = ?", item.barcode)
+      where("data -> 'item' -> 'barcode' ? '#{item.barcode}'")
   end
 
   def for_shelf(shelf)
     relation.
-      where("data -> 'shelf' ->> 'barcode' = ?", shelf.barcode)
+      where("data -> 'shelf' -> 'barcode' ? '#{shelf.barcode}'")
   end
 
   private_class_method :relation

--- a/app/queries/activity_log_query.rb
+++ b/app/queries/activity_log_query.rb
@@ -38,12 +38,12 @@ module ActivityLogQuery
 
   def for_item(item)
     relation.
-      where("data -> 'item' -> 'barcode' ? '#{item.barcode}'")
+      where("data -> 'item' -> 'barcode' ? :barcode", barcode: item.barcode)
   end
 
   def for_shelf(shelf)
     relation.
-      where("data -> 'shelf' -> 'barcode' ? '#{shelf.barcode}'")
+      where("data -> 'shelf' -> 'barcode' ? :barcode", barcode: shelf.barcode)
   end
 
   private_class_method :relation

--- a/db/migrate/20150814204601_add_item_tray_barcode_index.rb
+++ b/db/migrate/20150814204601_add_item_tray_barcode_index.rb
@@ -1,0 +1,16 @@
+class AddItemTrayBarcodeIndex < ActiveRecord::Migration
+  def up
+    execute("create index idxgin_data_item_barcode ON
+             activity_logs USING
+             gin ((data -> 'item' -> 'barcode'))")
+
+    execute("create index idxgin_data_shelf_barcode ON
+             activity_logs USING
+             gin ((data -> 'shelf' -> 'barcode'))")
+  end
+
+  def down
+    execute("drop index idxgin_data_item_barcode")
+    execute("drop index idxgin_data_shelf_barcode")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150728200747) do
+ActiveRecord::Schema.define(version: 20150814204601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Why: Item/shelf detail report is extremely slow.
How: Analyzed the query that this report uses and found that adding an index on data->item->barcode and data->shelf->barcode will speed up the query substantially. Added these indices and changed the query to use the ? operator to make use of the indices.