### PR TITLE
AIMS-317: Request date not showing correct date

### DIFF
--- a/app/services/get_requests.rb
+++ b/app/services/get_requests.rb
@@ -72,7 +72,7 @@ class GetRequests
       "trans" => trans,
       "criteria_type" => criteria_type,
       "criteria" => criteria,
-      "requested" => Date.today.to_s, # Should be date requested, but that doesn"t seem available.
+      "requested" => request_data["request_date_time"],
       "rapid" => rapid,
       "source" => source,
       "del_type" => del_type,


### PR DESCRIPTION
Why: The requested date does not reflect when the request was actually created.
How: Changed the requested field to use the request_date_time received from the api instead of todays date.