### PR TITLE
AIMS-310: Autofocus on search criteria to make scanner easier to use

### DIFF
--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -3,7 +3,7 @@
     %a.list-group-item.list-group-item-success Criteria
     #criteria.input-group
       = select_tag :criteria_type, options_for_select(SearchItems::CRITERIA_TYPES, @params[:criteria_type])
-      = text_field_tag :criteria, @params[:criteria]
+      = text_field_tag :criteria, @params[:criteria], autofocus: "autofocus"
       = label_tag :criteria, 'Use * for wildcard matches.'
 
     %a.list-group-item.list-group-item-success{"data-toggle" => "collapse", :href => "#date-range"}


### PR DESCRIPTION
Why: To simplify usage with the scanner
How: Added autofocus to the criteria box on item search. 