### PR TITLE
AIMS-315: Directed put away info not visible

### DIFF
--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -92,6 +92,14 @@ section {
     .doNotPrint, .doNotPrint * { display: none !important; }
 }
 
+.compact {
+  p {
+    padding: 0px 0 0 0;
+    margin: 0px 0;
+    line-height: 14px;
+  }
+}
+
 .container > .navbar-header,
   main > .navbar-header,
   .container > .navbar-collapse,
@@ -427,4 +435,3 @@ td:before {
   }
 
 }
-

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -94,9 +94,9 @@ section {
 
 .compact {
   p {
-    padding: 0;
-    margin: 0;
     line-height: 14px;
+    margin: 0;
+    padding: 0;
   }
 }
 

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -94,8 +94,8 @@ section {
 
 .compact {
   p {
-    padding: 0px 0 0 0;
-    margin: 0px 0;
+    padding: 0;
+    margin: 0;
     line-height: 14px;
   }
 }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,12 +1,4 @@
 %h2 Scan Item/Tray
-= form_tag item_restock_path(@item) do |f|
-  .scan
-    .field
-      = label_tag :barcode, "Item or Tray"
-      = text_field_tag :barcode, nil, autofocus: "autofocus"
-    .actions
-      = submit_tag 'Scan', class: 'btn btn-primary'
-
 %p
   Shelf Location:
   = (@item.tray.nil? ? 'STAGING' : (@item.tray.shelf.nil? ? 'STAGING' : @item.tray.shelf.barcode))
@@ -22,4 +14,10 @@
 %p
   Chron:
   = @item.chron
-%br
+
+= form_tag item_restock_path(@item) do |f|
+  .scan
+    .field
+      = label_tag :barcode, "Item or Tray"
+      = text_field_tag :barcode, nil, autofocus: "autofocus"
+      = submit_tag 'Scan', class: 'btn btn-primary'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -18,6 +18,5 @@
 = form_tag item_restock_path(@item) do |f|
   .scan
     .field
-      = label_tag :barcode, "Item or Tray"
       = text_field_tag :barcode, nil, autofocus: "autofocus"
       = submit_tag 'Scan', class: 'btn btn-primary'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,22 +1,28 @@
 %h2 Scan Item/Tray
-%p
-  Shelf Location:
-  = (@item.tray.nil? ? 'STAGING' : (@item.tray.shelf.nil? ? 'STAGING' : @item.tray.shelf.barcode))
-%p
-  Tray Number:
-  = (@item.tray.nil? ? 'STAGING' : @item.tray.barcode)
-%p
-  Title:
-  = @item.title
-%p
-  Author:
-  = @item.author
-%p
-  Chron:
-  = @item.chron
+%div.compact
+  %p
+    %b Shelf Location:
+    %i
+      = (@item.tray.nil? ? 'STAGING' : (@item.tray.shelf.nil? ? 'STAGING' : @item.tray.shelf.barcode))
+  %p
+    %b Tray Number:
+    %i
+      = (@item.tray.nil? ? 'STAGING' : @item.tray.barcode)
+  %p
+    %b Title:
+    %i
+      = @item.title
+  %p
+    %b Author:
+    %i
+      = @item.author
+  %p
+    %b Chron:
+    %i
+      = @item.chron
 
-= form_tag item_restock_path(@item) do |f|
-  .scan
-    .field
-      = text_field_tag :barcode, nil, autofocus: "autofocus"
-      = submit_tag 'Scan', class: 'btn btn-primary'
+  = form_tag item_restock_path(@item) do |f|
+    .scan
+      .field
+        = text_field_tag :barcode, nil, autofocus: "autofocus"
+        = submit_tag 'Scan', class: 'btn btn-primary'

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -43,7 +43,7 @@ feature "Items", type: :feature do
         fill_in "Item", with: @item.barcode
         click_button "Find"
         expect(current_path).to eq(show_item_path(id: @item.id))
-        fill_in "Item", with: @item.barcode
+        fill_in "barcode", with: @item.barcode
         click_button "Scan"
         expect(current_path).to eq(show_item_path(id: @item.id))
         expect(page).to have_content @item.title
@@ -55,7 +55,7 @@ feature "Items", type: :feature do
         fill_in "Item", with: @item.barcode
         click_button "Find"
         expect(current_path).to eq(show_item_path(id: @item.id))
-        fill_in "Tray", with: @tray.barcode
+        fill_in "barcode", with: @tray.barcode
         click_button "Scan"
         expect(current_path).to eq(items_path)
         expect(page).to have_content "Item #{@item.barcode} stocked in #{@tray.barcode}."
@@ -66,7 +66,7 @@ feature "Items", type: :feature do
         fill_in "Item", with: @item.barcode
         click_button "Find"
         expect(current_path).to eq(show_item_path(id: @item.id))
-        fill_in "Tray", with: @tray2.barcode
+        fill_in "barcode", with: @tray2.barcode
         click_button "Scan"
         expect(current_path).to eq(wrong_restock_path(id: @item.id))
         expect(page).to have_content "Item #{@item.barcode} is already assigned to #{@tray.barcode}."


### PR DESCRIPTION
Why: When scanning an item in directed put away, the info appears at the bottom. The screen on the scanner is fairly small, and this info gets cut off. Reworked the layout of this form to make all needed info visible.
How: Had to remove a label, move the info to the top, and make the paragraphs a little more compact in order to accommodate for the info, inputs, and error message.