### PR TITLE
AIMS-299, AIMS-281 improve items with issues table

### DIFF
--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -7,16 +7,15 @@
       %tr
         %th= 'Barcode'
         %th= 'Type'
-        %th= 'Message'
         %th= 'Created'
         %th= 'User'
         %th= ''
+        %th= 'Created Timestamp'
     %tbody
       - @issues.each do |issue|
         %tr
           %td= link_to issue.barcode, item_detail_path(issue.barcode)
           %td= t "issues.issue_type.#{issue.issue_type}"
-          %td= issue.message
           %td= issue.created_at.strftime("%m-%d-%Y %I:%M%p")
           %td= issue.user ? issue.user.username : "system"
           %td
@@ -24,8 +23,34 @@
               = hidden_field_tag :issue_id, issue.id
               .actions
                 = submit_tag 'Resolve', class: 'btn btn-primary', id: "issue-#{issue.id}"
+          %td= issue.created_at.to_i
   :javascript
       $(document).ready(function() {
-        window.table = $('#issues').DataTable();
+        var columns = {
+          barcode: 0,
+          type: 1,
+          createdDisplay: 2,
+          user: 3,
+          action: 4,
+          createdTimestamp: 5,
+        }
+        window.table = $('#issues').DataTable({
+          columnDefs: [
+            {
+              targets: columns.barcode,
+              width: '100px',
+            },
+            {
+              targets: columns.createdDisplay,
+              orderData: [columns.createdTimestamp],
+            },
+            {
+              targets: columns.createdTimestamp,
+              searchable: false,
+              visible: false,
+            }
+          ],
+        });
+        $('#issues').width("100%");
         $('div.dataTables_filter input').focus();
       } );

--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -15,7 +15,10 @@
       - @issues.each do |issue|
         %tr
           %td= link_to issue.barcode, item_detail_path(issue.barcode)
-          %td= t "issues.issue_type.#{issue.issue_type}"
+          %td
+            =t "issues.issue_type.#{issue.issue_type}"
+            %br
+            %small= issue.message
           %td= issue.created_at.strftime("%m-%d-%Y %I:%M%p")
           %td= issue.user ? issue.user.username : "system"
           %td

--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -17,8 +17,9 @@
           %td= link_to issue.barcode, item_detail_path(issue.barcode)
           %td
             =t "issues.issue_type.#{issue.issue_type}"
-            %br
-            %small= issue.message
+            - if issue.message.present?
+              %br
+              %small= issue.message
           %td= issue.created_at.strftime("%m-%d-%Y %I:%M%p")
           %td= issue.user ? issue.user.username : "system"
           %td


### PR DESCRIPTION
AIMS-299: Adjustments to the display issues table to limit text wrapping:

1. Removed the "Message" column, and if the message is present, display it under the type
2. Limit the width of the barcode column

AIMS-281: Fixed created date sorting
1. Added a hidden timestamp column to use as sorting data for the Created column
2. Barcode sorting appears to be working just fine.