### PR TITLE
AIMS-318: Too many items for a request

### DIFF
--- a/app/services/build_request_data.rb
+++ b/app/services/build_request_data.rb
@@ -34,6 +34,10 @@ class BuildRequestData
       }
 
       if !items.blank?
+        if items.total_pages > 1
+          request_data["error"] = "Too many matches found. Not all items are being displayed."
+        end
+
         items.each do |item|
           temp = {
             "id" => "#{request.id}-#{item.id}",

--- a/app/services/search_items.rb
+++ b/app/services/search_items.rb
@@ -35,7 +35,7 @@ class SearchItems
     if filter[:criteria].blank? && filter[:conditions].blank? && filter[:date_type].blank?
       results = empty
     else
-      count = 50 # We could customize this, but let's stick with 50 for now.
+      count = 5_000 # We could customize this, but let's stick with 5,000 for now.
       if filter[:page].blank?
         page = 1
       else

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -29,7 +29,7 @@
         %th= 'Remove Request'
     %tbody
       - @data.each do |row|
-        %tr{"data-params" => row['item_data'].to_json}
+        %tr{"data-items" => row['item_data'].to_json, "data-error" => row['error'] }
           %td
             %div{class: "details-control btn btn-primary", "id" => 'request_' + row['id'].to_s}= 'Results'
           %td= row['rapid']
@@ -114,43 +114,66 @@
     $(".details-control").click(function() {
       var tr = $(this).closest('tr');
       var row = table.row( tr );
-      console.log("my row: %o", tr)
+
+      // if this is the first click, the child row needs to be created
+      if(!row.child()) {
+        createChild(tr.data.bind(tr), row);
+      }
+
       if ( row.child.isShown() ) {
         // This row is already open - close it
         row.child.hide();
         tr.removeClass('shown');
       }
       else {
-        // Open this row
-        row.child( format(tr.data("params")) ).show();
+        row.child.show();
         tr.addClass('shown');
       };
-    } );
+    });
   };
+
+  function createChild(data, parent) {
+    var child = "";
+    if(data("error")) {
+      child = "<div class='alert-danger'>" + data("error") + "</div>";
+    }
+    child += format(data("items"));
+    parent.child(child);
+  }
+
   function format(json) {
-    console.log("my object: %o", json)
     if (json.length < 1) {
       str = "No results.";
     }
     else {
       str = "<table class='table table-striped condensed datatable'>";
+      str += "<tr>";
       str += "<th>Add to Batch</th>";
       str += "<th>Shelf</th>";
       str += "<th>Tray</th>";
       str += "<th>Title</th>";
       str += "<th>Author</th>";
       str += "<th>Chron</th>";
+      str += "</tr>";
       $.each(json, function( index, item ) {
         str += "<tr>";
-        if (item['status'] == 'stocked') {
-          str += "<td><input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' /></td>";
+        str += "<td>";
+        switch(item['status'])
+        {
+          case 'stocked':
+            str += "<input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' />";
+            break;
+          case 'unstocked':
+            str += "<span style='color: red'>Unstocked</span>";
+            break;
+          case 'shipped':
+            str += "<span style='color: red'>Shipped</span>";
+            break;
+          default:
+            str += "<span style='color: red'>Unknown</span>"
+            break;
         }
-        if (item['status'] == 'unstocked') {
-          str += "<td><span style='color: red'>Unstocked</span></td>";
-        }
-        if (item['status'] == 'shipped') {
-          str += "<td><span style='color: red'>Shipped</span></td>";
-        }
+        str += "</td>";
         str += "<td>"+item['shelf']+"</td>";
         str += "<td>"+item['tray']+"</td>";
         str += "<td>"+item['title']+"</td>";
@@ -162,4 +185,3 @@
     }
     return str;
   };
-

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -117,7 +117,7 @@
 
       // if this is the first click, the child row needs to be created
       if(!row.child()) {
-        createChild(tr.data.bind(tr), row);
+        createChild(tr, row);
       }
 
       if ( row.child.isShown() ) {
@@ -132,12 +132,12 @@
     });
   };
 
-  function createChild(data, parent) {
+  function createChild(tr, parent) {
     var child = "";
-    if(data("error")) {
-      child = "<div class='alert-danger'>" + data("error") + "</div>";
+    if(tr.data("error")) {
+      child = "<div class='alert-danger'>" + tr.data("error") + "</div>";
     }
-    child += format(data("items"));
+    child += format(tr.data("items"));
     parent.child(child);
   }
 

--- a/spec/services/build_request_data_spec.rb
+++ b/spec/services/build_request_data_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe BuildRequestData do
+  let(:request_data) do
+    {
+      requested: "requested",
+      rapid: "yes",
+      source: "source",
+      del_type: "del_type",
+      req_type: "req_type",
+      title: "title",
+      author: "author",
+      description: "description",
+      barcode: "barcode",
+      isbn_issn: "isbn_issn",
+      bib_number: "bib_number"
+    }
+  end
+  let(:item_data) do
+    {
+      status: "status",
+      shelf: shelf,
+      tray: tray,
+      title: "title",
+      author: "author",
+      chron: "chron"
+    }
+  end
+  let(:requests) { [instance_double(Request, id: 1, criteria_type: "bib_number", criteria: "bib_number", **request_data)] }
+  let(:item) { instance_double(Item, id: 1, **item_data) }
+  let(:results) { instance_double(Sunspot::Search::PaginatedCollection, total_pages: 1) }
+  let(:search) { instance_double(Sunspot::Search::StandardSearch, results: results) }
+  let(:shelf) { instance_double(Shelf, barcode: "shelf_barcode") }
+  let(:tray) { instance_double(Tray, barcode: "tray_barcode") }
+
+  context "found items" do
+    before(:each) do
+      allow(SearchItems).to receive(:call).and_return(search)
+      allow(results).to receive(:each).and_yield(item)
+    end
+
+    it "returns request data" do
+      result = described_class.call(requests)
+      expect(result[0].symbolize_keys).to include(request_data)
+    end
+
+    it "returns item data for the request" do
+      result = described_class.call(requests)
+      expected_item_data = { id: "1-1", status: "status", shelf: "shelf_barcode", tray: "tray_barcode", title: "title", author: "author", chron: "chron" }
+      expect(result[0]["item_data"]).to include(expected_item_data.stringify_keys)
+    end
+
+    it "returns no error when there aren't too many items to display for a request" do
+      result = described_class.call(requests)
+      expect(result[0]).not_to include("error")
+    end
+
+    it "returns an error when there are too many items to display for a request" do
+      allow(results).to receive(:total_pages).and_return(2)
+      result = described_class.call(requests)
+      expect(result[0]).to include("error")
+    end
+  end
+
+  context "no found items" do
+    before(:each) do
+      allow(SearchItems).to receive(:call).and_return(search)
+      allow(search).to receive(:results).and_return(nil)
+    end
+
+    it "returns request data" do
+      result = described_class.call(requests)
+      expect(result[0].symbolize_keys).to include(request_data)
+    end
+
+    it "returns no item data for the request" do
+      result = described_class.call(requests)
+      expect(result[0]["item_data"]).to eq([])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,7 +92,10 @@ RSpec.configure do |config|
     # Preload the fields for ActiveRecord objects to allow use of instance_double
     [
       Item,
-      User
+      User,
+      Request,
+      Tray,
+      Shelf
     ].each do |database_model|
       instance = database_model.new
       # The first attribute is id, which does not cause the methods to be built on the class


### PR DESCRIPTION
Why: If a request has many items that match, it does not show all items that it should.
How: Changed to retrieve 5,000 items per page instead of 50. There is still no way to go to next page of items (without a redesign), so if there are more than 5k items (more than one page) it will send an error message in with the hash of item data. The js that processes this will now print the error to the user to notify them that the request is likely bad.

Example:
![screen shot 2015-09-01 at 3 48 27 pm](https://cloud.githubusercontent.com/assets/11502744/9614683/2552d5b4-50c1-11e5-87ad-c4aae7e7b3e2.png)