### PR TITLE
AIMS-300 save the state of the issues table

### DIFF
--- a/app/views/items/issues.html.haml
+++ b/app/views/items/issues.html.haml
@@ -39,6 +39,8 @@
           createdTimestamp: 5,
         }
         window.table = $('#issues').DataTable({
+          stateSave: true,
+          stateDuration: 60 * 5,
           columnDefs: [
             {
               targets: columns.barcode,


### PR DESCRIPTION
Datatables has built-in support for saving the state of the table via local storage.  This saves it for a short time (5 minutes), so if the user leaves the page and then comes back, the table will be in the state that it was in when they left the page.