### PR TITLE
AIMS-319 Track pickup location, patron institution, department, and status

### DIFF
--- a/app/services/get_requests.rb
+++ b/app/services/get_requests.rb
@@ -83,7 +83,11 @@ class GetRequests
       "description" => request_data["description"],
       "barcode" => request_data["barcode"],
       "isbn_issn" => request_data["isbn_issn"],
-      "bib_number" => request_data["bib_number"]
+      "bib_number" => request_data["bib_number"],
+      "patron_institution" => request_data["patron_institution"],
+      "patron_department" => request_data["patron_department"],
+      "patron_status" => request_data["patron_status"],
+      "pickup_location" => request_data["pickup_location"],
     }
   end
 

--- a/db/migrate/20150901194225_add_patron_fields_to_requests.rb
+++ b/db/migrate/20150901194225_add_patron_fields_to_requests.rb
@@ -1,0 +1,8 @@
+class AddPatronFieldsToRequests < ActiveRecord::Migration
+  def change
+    add_column :requests, :patron_institution, :string
+    add_column :requests, :patron_department, :string
+    add_column :requests, :patron_status, :string
+    add_column :requests, :pickup_location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150814204601) do
+ActiveRecord::Schema.define(version: 20150901194225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,15 +101,15 @@ ActiveRecord::Schema.define(version: 20150814204601) do
   add_index "matches", ["item_id", "request_id", "batch_id"], name: "index_matches_on_item_id_and_request_id_and_batch_id", unique: true, using: :btree
 
   create_table "requests", force: :cascade do |t|
-    t.string   "criteria_type",              null: false
-    t.string   "criteria",                   null: false
+    t.string   "criteria_type",                   null: false
+    t.string   "criteria",                        null: false
     t.integer  "item_id"
     t.date     "requested"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.boolean  "rapid",                      null: false
-    t.string   "source",                     null: false
-    t.string   "req_type",                   null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.boolean  "rapid",                           null: false
+    t.string   "source",                          null: false
+    t.string   "req_type",                        null: false
     t.integer  "batch_id"
     t.string   "trans"
     t.string   "title"
@@ -119,8 +119,12 @@ ActiveRecord::Schema.define(version: 20150814204601) do
     t.string   "barcode"
     t.string   "isbn_issn"
     t.string   "bib_number"
-    t.string   "del_type",      default: "", null: false
-    t.integer  "status",        default: 0
+    t.string   "del_type",           default: "", null: false
+    t.integer  "status",             default: 0
+    t.string   "patron_institution"
+    t.string   "patron_department"
+    t.string   "patron_status"
+    t.string   "pickup_location"
   end
 
   add_index "requests", ["batch_id"], name: "index_requests_on_batch_id", using: :btree

--- a/spec/services/get_requests_spec.rb
+++ b/spec/services/get_requests_spec.rb
@@ -18,4 +18,60 @@ RSpec.describe GetRequests do
     expect(ActivityLogger).to receive(:receive_request).with(request: kind_of(Request)).exactly(4).times
     subject
   end
+
+  describe "request data" do
+    let(:requests_data) { { requests: [data] } }
+    let(:data) do
+      {
+        transaction: "aleph-000367092",
+        request_date_time: "2015-08-28T15:00:00Z",
+        request_type: "Doc Del",
+        delivery_type: "Loan",
+        source: "Aleph",
+        title: "Chemistry in Britain.",
+        author: "author",
+        description: "v.25 (1989)",
+        pages: "pages",
+        journal_title: "journal_title",
+        article_title: "article_title",
+        article_author: "article_author",
+        barcode: "00000014443212",
+        isbn_issn: "isbn_issn",
+        bib_number: "000663270",
+        adm_number: "000663270",
+        ill_system_id: "ill_system_id",
+        item_sequence: "00070",
+        call_number: "TP 1 .C5174",
+        send_to: "Hesburgh Library",
+        rush: "No",
+        patron_status: "Grad",
+        patron_department: "Chemical Engineering",
+        patron_institution: "University of Notre Dame",
+        pickup_location: "Hesburgh Library"
+      }
+    end
+    let(:request) { subject.first }
+
+    before do
+      stub_api_active_requests(body: requests_data.to_json)
+    end
+
+    it "sets expected values" do
+      [
+        :title,
+        :article_title,
+        :author,
+        :description,
+        :barcode,
+        :isbn_issn,
+        :bib_number,
+        :patron_status,
+        :patron_department,
+        :patron_institution,
+        :pickup_location,
+      ].each do |field|
+        expect(request.send(field)).to eq(data.fetch(field))
+      end
+    end
+  end
 end


### PR DESCRIPTION
What: They want to be able to do reporting on requests using the patron status (Grad/Undergrad), patron institution, patron department, and pickup location for requests.

I added four new fields to the request table and set their values from the data returned by the API.

I also need the `AIMS-319-request-patron-info` branch reviewed on the API repository.