### PR TITLE
AIMS-272: Log activity when removing a match

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -41,6 +41,7 @@ class BatchesController < ApplicationController
     if !params[:match_id].blank?
       match = Match.find(params[:match_id])
       if !match.blank?
+        ActivityLogger.remove_match(item: match.item, request: match.request, user: current_user)
         match.destroy!
       end
     end

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -82,6 +82,10 @@ class ActivityLogger
     call(action: "ReceivedRequest", request: request)
   end
 
+  def self.remove_match(item:, request:, user:)
+    call(action: "RemovedMatch", item: item, request: request, user: user)
+  end
+
   def self.remove_request(request:, user:)
     call(action: "RemovedRequest", request: request, user: user)
   end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe BatchesController, type: :controller do
       get :scan_bin, commit: "Skip"
     end
   end
+
+  describe "remove match" do
+    it "logs a RemovedMatch activity" do
+      allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
+      expect(ActivityLogger).to receive(:remove_match)
+      post :remove, commit: "Remove", match_id: match.id
+    end
+  end
 end

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -188,6 +188,13 @@ RSpec.describe ActivityLogger do
     it_behaves_like "an activity log", "ReceivedRequest"
   end
 
+  context "RemovedMatch" do
+    let(:arguments) { { item: item, request: request, user: user } }
+    subject { described_class.remove_match(**arguments) }
+
+    it_behaves_like "an activity log", "RemovedMatch"
+  end
+
   context "RemovedRequest" do
     let(:arguments) { { request: request, user: user } }
     subject { described_class.remove_request(**arguments) }


### PR DESCRIPTION
Why: If a user removes a match on the "View Current Batch" screen, it is not logging the activity and we need it for reporting
How: Added a RemovedMatch activity log and modified batches controller to log this activity any time the user removes a matched item from a batch.