### PR TITLE
AIMS-322 error handling and debugging for requests sync

### DIFF
--- a/spec/services/get_requests_spec.rb
+++ b/spec/services/get_requests_spec.rb
@@ -73,5 +73,11 @@ RSpec.describe GetRequests do
         expect(request.send(field)).to eq(data.fetch(field))
       end
     end
+
+    it "calls NotifyError on an error and doesn't return a request" do
+      expect_any_instance_of(Request).to receive(:save!).and_raise("error!")
+      expect(NotifyError).to receive(:call).and_call_original
+      expect(request).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Currently when requests are loaded from the API, an error on an individual request will break the entire process and will not provide any helpful debugging information.

This adds error handling around individual request processing so an error will not stop the entire process.