### PR TITLE
AIMS-243 Commented out code to skip remaining items in request

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -63,7 +63,6 @@ class BatchesController < ApplicationController
       redirect_to finalize_batch_path
       return
     end
-
   end
 
   def item
@@ -111,7 +110,6 @@ class BatchesController < ApplicationController
     end
 
     @match = @batch.current_match
-
   end
 
   def scan_bin

--- a/app/services/accept_match.rb
+++ b/app/services/accept_match.rb
@@ -16,11 +16,5 @@ class AcceptMatch
     @match.request.filled_by_item = @match.item
     @match.request.filled_in_batch = @match.batch
     @match.request.save!
-
-    @match.batch.unprocessed_matches_for_request(@match.request).each do |un|
-      un.processed = "skipped"
-      un.save!
-    end
   end
-
 end


### PR DESCRIPTION
What: Disabled the automatic skip of remaining items in a batch for a request so that multiple items can be selected to fulfill a request
How: Commented out four lines of code in the AcceptMatch service class