### PR TITLE
AIMS-321: Batch items filter

### DIFF
--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -29,7 +29,7 @@
         %th= 'Remove Request'
     %tbody
       - @data.each do |row|
-        %tr{"data-items" => row['item_data'].to_json, "data-error" => row['error'] }
+        %tr{"id" => "request-" + row['id'].to_s, "data-items" => row['item_data'].to_json, "data-error" => row['error'] }
           %td
             %div{class: "details-control btn btn-primary", "id" => 'request_' + row['id'].to_s}= 'Results'
           %td= row['rapid']
@@ -137,16 +137,29 @@
     if(tr.data("error")) {
       child = "<div class='alert-danger'>" + tr.data("error") + "</div>";
     }
-    child += format(tr.data("items"));
+    child += format(tr);
     parent.child(child);
+
+    // Add datatable to the child table
+    parent.child().find('table').DataTable(
+      {
+        "paging": false,
+        "ordering": true,
+        "searching": false,
+        "info": false
+      }
+    );
   }
 
-  function format(json) {
+  function format(tr) {
+    json = tr.data('items');
     if (json.length < 1) {
       str = "No results.";
     }
     else {
-      str = "<table class='table table-striped condensed datatable'>";
+      str = "<table id='" + tr.attr('id') + "-items' class='table table-striped condensed datatable'>";
+
+      str += "<thead>";
       str += "<tr>";
       str += "<th>Add to Batch</th>";
       str += "<th>Shelf</th>";
@@ -155,6 +168,9 @@
       str += "<th>Author</th>";
       str += "<th>Chron</th>";
       str += "</tr>";
+      str += "</thead>";
+
+      str += "<tbody>";
       $.each(json, function( index, item ) {
         str += "<tr>";
         str += "<td>";
@@ -181,6 +197,8 @@
         str += "<td>"+item['chron']+"</td>";
         str += "</tr>";
       } );
+      str += "</tbody>";
+
       str += "</table>";
     }
     return str;

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -50,8 +50,21 @@
   .actions
     = submit_tag 'Save', class: 'btn btn-primary'
 :javascript
+  // Test a specific instance of data table settings to determine if
+  // we should skip applying the top level request filters.
+  // Returns true if "useRequestFilters" is not set on the instance
+  function skipRequestFilters(settings){
+    var api = new $.fn.dataTable.Api( settings );
+    return !settings.oInit.useRequestFilters;
+  }
+
+  // Add filter by source to all DataTables
   $.fn.dataTable.ext.search.push(
     function( settings, data, dataIndex ) {
+      if(skipRequestFilters(settings)) {
+        return true;
+      }
+
       var select_source = $('#source').val().toLowerCase();
       var data_source = data[2].toLowerCase();
       if (select_source == data_source) {
@@ -60,8 +73,14 @@
       return false;
     }
   );
+
+  // Add filter by request type to all DataTables
   $.fn.dataTable.ext.search.push(
     function( settings, data, dataIndex ) {
+      if(skipRequestFilters(settings)) {
+        return true;
+      }
+
       var select_req = $('#req_type').val().toLowerCase();
       var data_req = data[3].toLowerCase();
       if (select_req == data_req) {
@@ -70,8 +89,14 @@
       return false;
     }
   );
+
+  // Add filter by rapid requests to all DataTables
   $.fn.dataTable.ext.search.push(
     function( settings, data, dataIndex ) {
+      if(skipRequestFilters(settings)) {
+        return true;
+      }
+
       var checkbox_rapid = $('#rapid').is(':checked');
       var data_rapid = data[1].toLowerCase();
       if (checkbox_rapid) {
@@ -85,8 +110,10 @@
       }
     }
   );
+
   $(document).ready(function() {
     window.table = $('#requests').DataTable( {
+        "useRequestFilters": true,
         "dom": 'T<"clear">lfrtip',
         "tableTools": {
           "aButtons": [ {
@@ -105,10 +132,12 @@
           addHandler();
         }
     } );
+    
     $("#selectAll").click(function() {
       $(".item").prop("checked", $("#selectAll").prop("checked"));
     } );
   } );
+
   function addHandler() {
     $(".details-control").unbind('click');
     $(".details-control").click(function() {
@@ -143,9 +172,9 @@
     // Add datatable to the child table
     parent.child().find('table').DataTable(
       {
+        "useRequestFilters": false,
         "paging": false,
         "ordering": true,
-        "searching": false,
         "info": false
       }
     );


### PR DESCRIPTION
Why: User would like to additionally be able to filter the items that match a request.
How: Each sub table will now use DataTables. I also had to modify the way that the global request filters work since these are applied to all datatables, not just specific instances. 