### PR TITLE
Batch items results list styles and enhancements

### DIFF
--- a/app/assets/stylesheets/batches.css.scss
+++ b/app/assets/stylesheets/batches.css.scss
@@ -1,0 +1,21 @@
+.table > tbody > tr.batch-request-results-row > td {
+  border-top-style: dashed;
+}
+
+.batch-request-results {
+  border-left: 1px solid #ddd;
+  padding: 0 0 1em 2em;
+
+  .dataTables_filter {
+    float: left;
+    margin-right: 1em;
+
+    label {
+      float: none;
+    }
+  }
+
+  .dataTables_length {
+    float: left;
+  }
+}

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -133,9 +133,16 @@
         }
     } );
 
-    $("#selectAll").click(function() {
-      $(".item").prop("checked", $("#selectAll").prop("checked"));
+    $("#selectAll").click(function(event) {
+      event.stopPropagation();
+      $(".item").prop("checked", $("#selectAll").prop("checked")).each(function() {
+        checkboxChanged(this);
+      });
     } );
+
+    $("form").on("change", ".item", function() {
+      checkboxChanged(this);
+    });
   } );
 
   function addHandler() {
@@ -160,6 +167,7 @@
       };
     });
   };
+
   var resultsColumns = {
     "status": 0,
     "shelf": 1,
@@ -261,7 +269,7 @@
         switch(item['status'])
         {
           case 'stocked':
-            rowData.status = "<input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' />";
+            rowData.status = "<input class='item' type='checkbox' id='"+item['id']+"' value='"+item['id']+"' />";
             break;
           case 'unstocked':
             rowData.status = "<span style='color: red'>Unstocked</span>";
@@ -289,4 +297,21 @@
       columns[resultsColumns[key]] = "" + rowData[key];
     }
     return columns;
+  }
+
+  function checkboxChanged(checkbox) {
+    var $checkbox = $(checkbox);
+    console.log(checkbox);
+    var $form = $checkbox.parents("form");
+    var hiddenID = "hidden-" + $checkbox.attr("id");
+    var $hiddenField = $form.find("#" + hiddenID);
+    if ($checkbox.prop("checked")) {
+      if ($hiddenField.length == 0) {
+        $hiddenField = $("<input type='hidden' name='batch[]'>");
+        $hiddenField.attr("id", hiddenID).attr("value", $checkbox.attr("value"));
+        $form.append($hiddenField);
+      }
+    } else {
+      $hiddenField.remove();
+    }
   }

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -132,7 +132,7 @@
           addHandler();
         }
     } );
-    
+
     $("#selectAll").click(function() {
       $(".item").prop("checked", $("#selectAll").prop("checked"));
     } );
@@ -167,17 +167,36 @@
       child = "<div class='alert-danger'>" + tr.data("error") + "</div>";
     }
     child += format(tr);
-    parent.child(child);
+    child = "<div class='batch-request-results'>" + child + "</div>";
+    // Add two child rows and hide the first to prevent zebra striping from
+    //  coloring the child row differently than the parent row
+    var rows = ["", child]
+    parent.child(rows);
+    var children = parent.child();
+    children.first().hide();
+    var resultsRow = children.last()
+    resultsRow.addClass('batch-request-results-row');
 
     // Add datatable to the child table
-    parent.child().find('table').DataTable(
-      {
-        "useRequestFilters": false,
-        "paging": false,
-        "ordering": true,
-        "info": false
-      }
-    );
+    var options = {
+      "dom": "<'row'<'col-sm-12'fl>>" +
+        "<'row'<'col-sm-12'tr>>" +
+        "<'row'<'col-sm-5'i><'col-sm-7'p>>",
+      "useRequestFilters": false,
+      "searching": false,
+      "paging": false,
+      "ordering": true,
+      "info": false,
+      "order": [[ 5, "asc" ]], // Sort by chron by default
+    }
+
+    if (tr.data('items').length > 10) {
+      options.searching = true;
+      options.paging = true;
+      options.info = true;
+    }
+
+    resultsRow.find('table').DataTable(options);
   }
 
   function format(tr) {

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -166,7 +166,8 @@
     "tray": 2,
     "title": 3,
     "author": 4,
-    "chron": 5
+    "chron": 5,
+    "chronSort": 6,
   }
 
   function createChild(tr, parent) {
@@ -196,6 +197,17 @@
       "ordering": true,
       "info": false,
       "order": [[ resultsColumns.chron, "asc" ]], // Sort by chron by default
+      "columnDefs": [
+        {
+          targets: resultsColumns.chron,
+          orderData: [resultsColumns.chronSort],
+        },
+        {
+          targets: resultsColumns.chronSort,
+          searchable: false,
+          visible: false,
+        },
+      ],
     }
 
     if (tr.data('items').length > 10) {
@@ -203,8 +215,9 @@
       options.paging = true;
       options.info = true;
     }
-
-    resultsRow.find('table').DataTable(options);
+    var resultsTable = resultsRow.find('table');
+    resultsTable.DataTable(options);
+    resultsTable.width("100%");
   }
 
   function format(tr) {
@@ -223,6 +236,7 @@
         "title": "Title",
         "author": "Author",
         "chron": "Chron",
+        "chronSort": "Chron Sort",
       };
       var columns = mapColumns(headerData);
       str += "<tr><th>" + columns.join("</th>\n<th>") + "</th></tr>";
@@ -238,6 +252,12 @@
           "author": item.author,
           "chron": item.chron,
         };
+        if (item.chron) {
+          // Find the first number in the chron string and use that value to sort
+          rowData.chronSort = item.chron.replace(/^[^\d]*([\d]+)[^\d]*.*$/, "$1");
+        } else {
+          rowData.chronSort = "";
+        }
         switch(item['status'])
         {
           case 'stocked':

--- a/app/views/batches/index.html.haml
+++ b/app/views/batches/index.html.haml
@@ -160,6 +160,14 @@
       };
     });
   };
+  var resultsColumns = {
+    "status": 0,
+    "shelf": 1,
+    "tray": 2,
+    "title": 3,
+    "author": 4,
+    "chron": 5
+  }
 
   function createChild(tr, parent) {
     var child = "";
@@ -187,7 +195,7 @@
       "paging": false,
       "ordering": true,
       "info": false,
-      "order": [[ 5, "asc" ]], // Sort by chron by default
+      "order": [[ resultsColumns.chron, "asc" ]], // Sort by chron by default
     }
 
     if (tr.data('items').length > 10) {
@@ -208,42 +216,45 @@
       str = "<table id='" + tr.attr('id') + "-items' class='table table-striped condensed datatable'>";
 
       str += "<thead>";
-      str += "<tr>";
-      str += "<th>Add to Batch</th>";
-      str += "<th>Shelf</th>";
-      str += "<th>Tray</th>";
-      str += "<th>Title</th>";
-      str += "<th>Author</th>";
-      str += "<th>Chron</th>";
+      var headerData = {
+        "status": "Add to Batch",
+        "shelf": "Shelf",
+        "tray": "Tray",
+        "title": "Title",
+        "author": "Author",
+        "chron": "Chron",
+      };
+      var columns = mapColumns(headerData);
+      str += "<tr><th>" + columns.join("</th>\n<th>") + "</th></tr>";
       str += "</tr>";
       str += "</thead>";
 
       str += "<tbody>";
       $.each(json, function( index, item ) {
-        str += "<tr>";
-        str += "<td>";
+        var rowData = {
+          "shelf": item.shelf,
+          "tray": item.tray,
+          "title": item.title,
+          "author": item.author,
+          "chron": item.chron,
+        };
         switch(item['status'])
         {
           case 'stocked':
-            str += "<input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' />";
+            rowData.status = "<input class='item' type='checkbox' name='batch[]' id='"+item['id']+"' value='"+item['id']+"' />";
             break;
           case 'unstocked':
-            str += "<span style='color: red'>Unstocked</span>";
+            rowData.status = "<span style='color: red'>Unstocked</span>";
             break;
           case 'shipped':
-            str += "<span style='color: red'>Shipped</span>";
+            rowData.status = "<span style='color: red'>Shipped</span>";
             break;
           default:
-            str += "<span style='color: red'>Unknown</span>"
+            rowData.status = "<span style='color: red'>Unknown</span>"
             break;
         }
-        str += "</td>";
-        str += "<td>"+item['shelf']+"</td>";
-        str += "<td>"+item['tray']+"</td>";
-        str += "<td>"+item['title']+"</td>";
-        str += "<td>"+item['author']+"</td>";
-        str += "<td>"+item['chron']+"</td>";
-        str += "</tr>";
+        var columns = mapColumns(rowData);
+        str += "<tr><td>" + columns.join("</td>\n<td>") + "</td></tr>";
       } );
       str += "</tbody>";
 
@@ -251,3 +262,11 @@
     }
     return str;
   };
+
+  function mapColumns(rowData) {
+    var columns = [];
+    for (var key in resultsColumns) {
+      columns[resultsColumns[key]] = "" + rowData[key];
+    }
+    return columns;
+  }


### PR DESCRIPTION
I perhaps went overboard in exploring this...

1. Indent the item list row slightly
2. Make sure the child row has the same background color as the parent row
3. Left align the search box
4. Conditionally show the search box and pagination if there are enough records.
5. Default to sorting by chron, added some hopefully intelligent sorting on chron so it sorts numerically rather than by string value

Example with filtering:
<img width="1195" alt="annex_ims" src="https://cloud.githubusercontent.com/assets/127832/9663184/2b2c27f8-5231-11e5-9e82-d2cf3c9dc85f.png">

Example without filtering:
<img width="1179" alt="annex_ims" src="https://cloud.githubusercontent.com/assets/127832/9663238/7395f99c-5231-11e5-95ab-fbc1ef117a51.png">
