### PR TITLE
AIMS-324 configurable item search per page

### DIFF
--- a/app/services/build_request_data.rb
+++ b/app/services/build_request_data.rb
@@ -14,7 +14,11 @@ class BuildRequestData
     data = []
 
     requests.each do |request|
-      filter = {:criteria_type => request.criteria_type, :criteria => request.criteria}
+      filter = {
+        criteria_type: request.criteria_type,
+        criteria: request.criteria,
+        per_page: 5_000,
+      }
       items = SearchItems.call(filter).results
 
       request_data = {

--- a/app/services/search_items.rb
+++ b/app/services/search_items.rb
@@ -19,15 +19,18 @@ class SearchItems
     @filter = filter
   end
 
-  class EmptyResults
-    def results
-      []
-    end
-
-    def total
-      0
-    end
-  end
+  # def criteria
+  #   fetch(:criteria)
+  # end
+  #
+  # def page
+  #   requested_page = fetch(:page)
+  #   if requested_page.present?
+  #     requested_page
+  #   else
+  #     1
+  #   end
+  # end
 
   def search!
     empty = EmptyResults.new
@@ -113,6 +116,22 @@ class SearchItems
 
     end
 
+  end
+
+  private
+
+  def fetch(key)
+    filter.fetch(key, nil)
+  end
+
+  class EmptyResults
+    def results
+      []
+    end
+
+    def total
+      0
+    end
   end
 
 end

--- a/app/services/search_items.rb
+++ b/app/services/search_items.rb
@@ -51,7 +51,7 @@ class SearchItems
 
   private
 
-  def search_results
+  def search_results # rubocop:disable Metrics/AbcSize
     Item.search do
       paginate page: page, per_page: per_page
 
@@ -126,7 +126,11 @@ class SearchItems
   end
 
   def fulltext_fields
-    @fulltext_fields ||= case fetch(:criteria_type)
+    @fulltext_fields ||= get_fulltext_fields
+  end
+
+  def get_fulltext_fields
+    case fetch(:criteria_type)
     when "any"
       [:barcode, :bib_number, :call_number, :isbn_issn, :title, :author, :tray_barcode, :shelf_barcode]
     when "barcode"

--- a/spec/services/build_request_data_spec.rb
+++ b/spec/services/build_request_data_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe BuildRequestData do
       allow(results).to receive(:each).and_yield(item)
     end
 
+    it "calls SearchItems with expected values" do
+      request = requests.first
+      expect(SearchItems).to receive(:call).
+        with(criteria_type: request.criteria_type, criteria: request.criteria, per_page: 5_000).
+        and_return(search)
+      described_class.call(requests)
+    end
+
     it "returns request data" do
       result = described_class.call(requests)
       expect(result[0].symbolize_keys).to include(request_data)

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -5,30 +5,21 @@ RSpec.describe SearchItems do
 
   before :all do
     solr_setup
-    Item.remove_all_from_index!
   end
 
   after :all do
     Item.remove_all_from_index!
   end
 
-  let(:unindexed_item) { FactoryGirl.create(:item, chron: "TEST CHRON") }
-  let(:item) do
-    Sunspot.index(unindexed_item)
-    Sunspot.commit
-    unindexed_item
-  end
+  let(:item) { FactoryGirl.create(:item, chron: "TEST CHRON") }
   let(:filter) { {} }
   subject { described_class.call(filter) }
   let(:results) { subject.results }
 
-  context "barcode" do
-    let(:filter) { { criteria_type: "barcode", criteria: item.barcode } }
-
-    it "can find an item by barcode" do
-      expect(subject).to be_kind_of(Sunspot::Search::StandardSearch)
-      expect(results.first).to eq item
-    end
+  before do
+    Item.remove_all_from_index!
+    Sunspot.index(item)
+    Sunspot.commit
   end
 
   context "no filter" do
@@ -76,7 +67,79 @@ RSpec.describe SearchItems do
         filter[:criteria] = item.shelf.barcode
         expect(results.first).to eq(item)
       end
+
+      it "does not match a nonexistant value" do
+        filter[:criteria] = "fake value"
+        expect(results).to eq([])
+      end
+    end
+
+    [
+      :barcode,
+      :bib_number,
+      :call_number,
+      :isbn_issn,
+      :title,
+      :author,
+    ].each do |criteria_type_field|
+      describe "#{criteria_type_field}" do
+        let(:filter) { { criteria_type: criteria_type_field.to_s } }
+        it "can find an item by #{criteria_type_field}" do
+          allow(item).to receive(criteria_type_field).and_return("#{criteria_type_field} value")
+          Sunspot.index(item)
+          Sunspot.commit
+          filter[:criteria] = item.send(criteria_type_field)
+          expect(results.first).to eq(item)
+        end
+
+        it "cannot find an item by #{criteria_type_field}" do
+          filter[:criteria] = "fake value"
+          expect(results).to eq([])
+        end
+      end
+    end
+
+    describe "tray" do
+      let(:filter) { { criteria_type: "tray" } }
+
+      it "searches the tray barcode" do
+        item.tray = FactoryGirl.create(:tray)
+        Sunspot.index(item)
+        Sunspot.commit
+        filter[:criteria] = item.tray.barcode
+        expect(results.first).to eq(item)
+      end
+
+      it "does not match a nonexistant value" do
+        filter[:criteria] = "fake value"
+        expect(results).to eq([])
+      end
+    end
+
+    describe "shelf" do
+      let(:filter) { { criteria_type: "shelf" } }
+
+      it "searches the shelf barcode" do
+        item.shelf = FactoryGirl.create(:shelf)
+        Sunspot.index(item)
+        Sunspot.commit
+        filter[:criteria] = item.shelf.barcode
+        expect(results.first).to eq(item)
+      end
+
+      it "does not match a nonexistant value" do
+        filter[:criteria] = "fake value"
+        expect(results).to eq([])
+      end
+    end
+
+    describe "ERROR" do
+      let(:filter) { { criteria_type: "ERROR", criteria: "ERROR" } }
+
+      it "returns an empty result set" do
+        filter[:criteria] = "ERROR"
+        expect(results).to eq([])
+      end
     end
   end
-
 end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -27,7 +27,17 @@ RSpec.describe SearchItems do
 
     it "returns an empty result" do
       expect(subject).to be_kind_of(described_class::EmptyResults)
-      expect(results).to eq []
+      expect(subject.results).to eq []
+      expect(subject.total).to eq(0)
+    end
+  end
+
+  context "page" do
+    let(:filter) { { criteria_type: "any", criteria: item.title, page: 2 } }
+
+    it "returns the second page of results" do
+      expect(subject.total).to eq(1)
+      expect(subject.results).to eq([])
     end
   end
 
@@ -262,6 +272,30 @@ RSpec.describe SearchItems do
       it "does not match if the finish date is before the request date" do
         filter[:finish] = filter_date.ago(1.day).to_s
         expect(results).to eq([])
+      end
+    end
+
+    {
+      initial: :initial_ingest,
+      last: :last_ingest,
+    }.each do |date_type, date_field|
+      context date_type.to_s do
+        let(:item) { FactoryGirl.create(:item, date_field => filter_date) }
+        let(:filter) { { date_type: date_type.to_s, start: filter_date.ago(1.week).to_s, finish: filter_date.since(1.week).to_s } }
+
+        it "matches the date" do
+          expect(results.first).to eq(item)
+        end
+
+        it "does not match if the start date is after the request date" do
+          filter[:start] = filter_date.since(1.day).to_s
+          expect(results).to eq([])
+        end
+
+        it "does not match if the finish date is before the request date" do
+          filter[:finish] = filter_date.ago(1.day).to_s
+          expect(results).to eq([])
+        end
       end
     end
   end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -314,14 +314,40 @@ RSpec.describe SearchItems do
           expect(results.first).to eq(item)
         end
 
-        it "does not match if the start date is after the request date" do
+        it "does not match if the start date is after the filter date" do
           filter[:start] = filter_date.since(1.day).to_s
           expect(results).to eq([])
         end
 
-        it "does not match if the finish date is before the request date" do
+        it "does not match if the finish date is before the filter date" do
           filter[:finish] = filter_date.ago(1.day).to_s
           expect(results).to eq([])
+        end
+
+        context "no start date" do
+          let(:filter) { { date_type: date_type.to_s, finish: filter_date.since(1.week).to_s } }
+
+          it "matches the date" do
+            expect(results.first).to eq(item)
+          end
+
+          it "does not match if the finish date is before the filter date" do
+            filter[:finish] = filter_date.ago(1.day).to_s
+            expect(results).to eq([])
+          end
+        end
+
+        context "no finish date" do
+          let(:filter) { { date_type: date_type.to_s, start: filter_date.ago(1.week).to_s } }
+
+          it "matches the date" do
+            expect(results.first).to eq(item)
+          end
+
+          it "does not match if the start date is after the filter date" do
+            filter[:start] = filter_date.since(1.day).to_s
+            expect(results).to eq([])
+          end
         end
       end
     end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -237,4 +237,32 @@ RSpec.describe SearchItems do
       end
     end
   end
+
+  context "date_type" do
+    let(:filter_date) { 1.week.ago }
+
+    context "request" do
+      let(:request) { FactoryGirl.create(:request, requested: filter_date) }
+      let(:item) do
+        FactoryGirl.create(:item).tap do |i|
+          allow(i).to receive(:requests).and_return([request])
+        end
+      end
+      let(:filter) { { date_type: "request", start: filter_date.ago(1.week).to_s, finish: filter_date.since(1.week).to_s } }
+
+      it "matches the request date" do
+        expect(results.first).to eq(item)
+      end
+
+      it "does not match if the start date is after the request date" do
+        filter[:start] = filter_date.since(1.day).to_s
+        expect(results).to eq([])
+      end
+
+      it "does not match if the finish date is before the request date" do
+        filter[:finish] = filter_date.ago(1.day).to_s
+        expect(results).to eq([])
+      end
+    end
+  end
 end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -142,4 +142,99 @@ RSpec.describe SearchItems do
       end
     end
   end
+
+  context "conditions" do
+    let(:conditions) { ["COVER-MISS", "PAGES-BRITTLE", "SPINE-DET"] }
+    let(:other_conditions) { ["COVER-TORN", "NEEDS-ENCLS"] }
+    let(:item) { FactoryGirl.create(:item, conditions: conditions) }
+
+    context "all" do
+      let(:filter) { { condition_bool: "all" } }
+
+      it "matches all conditions" do
+        filter[:conditions] = {}.tap do |hash|
+          conditions.each { |c| hash[c] = true }
+        end
+        expect(results.first).to eq(item)
+      end
+
+      it "matches partial conditions" do
+        filter[:conditions] = {}.tap do |hash|
+          conditions[0,2].each { |c| hash[c] = true }
+        end
+        expect(results.first).to eq(item)
+      end
+
+      it "does not match an extra condition" do
+        filter[:conditions] = {}.tap do |hash|
+          (conditions + other_conditions).each { |c| hash[c] = true }
+        end
+        expect(results).to eq([])
+      end
+    end
+
+    context "any" do
+      let(:filter) { { condition_bool: "any" } }
+
+      it "matches all conditions" do
+        filter[:conditions] = {}.tap do |hash|
+          conditions.each { |c| hash[c] = true }
+        end
+        expect(results.first).to eq(item)
+      end
+
+      it "matches partial conditions" do
+        filter[:conditions] = {}.tap do |hash|
+          conditions[0,2].each { |c| hash[c] = true }
+        end
+        expect(results.first).to eq(item)
+      end
+
+      it "matches as long as one condition matches" do
+        filter[:conditions] = {}.tap do |hash|
+          (conditions[0,1] + other_conditions).each { |c| hash[c] = true }
+        end
+        expect(results.first).to eq(item)
+      end
+
+      it "does not match if no conditions match" do
+        filter[:conditions] = {}.tap do |hash|
+          other_conditions.each { |c| hash[c] = true }
+        end
+        expect(results).to eq([])
+      end
+    end
+
+    context "any" do
+      let(:filter) { { condition_bool: "none" } }
+
+      it "does not match all conditions" do
+        filter[:conditions] = {}.tap do |hash|
+          conditions.each { |c| hash[c] = true }
+        end
+        expect(results).to eq([])
+      end
+
+      it "does not match partial conditions" do
+        filter[:conditions] = {}.tap do |hash|
+          conditions[0,2].each { |c| hash[c] = true }
+        end
+        expect(results).to eq([])
+      end
+
+      it "does not match if one condition matches" do
+        filter[:conditions] = {}.tap do |hash|
+          (conditions[0,1] + other_conditions).each { |c| hash[c] = true }
+        end
+        expect(results).to eq([])
+      end
+
+      it "matches if no conditions match" do
+        filter[:conditions] = {}.tap do |hash|
+          other_conditions.each { |c| hash[c] = true }
+        end
+        expect(results.first).to eq(item)
+      end
+    end
+  end
 end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe SearchItems do
 
       it "matches partial conditions" do
         filter[:conditions] = {}.tap do |hash|
-          conditions[0,2].each { |c| hash[c] = true }
+          conditions[0, 2].each { |c| hash[c] = true }
         end
         expect(results.first).to eq(item)
       end
@@ -222,14 +222,14 @@ RSpec.describe SearchItems do
 
       it "matches partial conditions" do
         filter[:conditions] = {}.tap do |hash|
-          conditions[0,2].each { |c| hash[c] = true }
+          conditions[0, 2].each { |c| hash[c] = true }
         end
         expect(results.first).to eq(item)
       end
 
       it "matches as long as one condition matches" do
         filter[:conditions] = {}.tap do |hash|
-          (conditions[0,1] + other_conditions).each { |c| hash[c] = true }
+          (conditions[0, 1] + other_conditions).each { |c| hash[c] = true }
         end
         expect(results.first).to eq(item)
       end
@@ -254,14 +254,14 @@ RSpec.describe SearchItems do
 
       it "does not match partial conditions" do
         filter[:conditions] = {}.tap do |hash|
-          conditions[0,2].each { |c| hash[c] = true }
+          conditions[0, 2].each { |c| hash[c] = true }
         end
         expect(results).to eq([])
       end
 
       it "does not match if one condition matches" do
         filter[:conditions] = {}.tap do |hash|
-          (conditions[0,1] + other_conditions).each { |c| hash[c] = true }
+          (conditions[0, 1] + other_conditions).each { |c| hash[c] = true }
         end
         expect(results).to eq([])
       end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -12,12 +12,27 @@ RSpec.describe SearchItems do
     Item.remove_all_from_index!
   end
 
-  it "can find an item by barcode" do
-    item = FactoryGirl.create(:item, chron: 'TEST CHRON')
-    Sunspot.index(item)
+  let(:unindexed_item) { FactoryGirl.create(:item, chron: "TEST CHRON") }
+  let(:item) do
+    Sunspot.index(unindexed_item)
     Sunspot.commit
-    search = SearchItems.call(criteria_type: "barcode", criteria: item.barcode)
-    expect(item).to eq search.results.first
+    unindexed_item
+  end
+  let(:filter) { {} }
+  subject { described_class.call(filter) }
+  let(:results) { subject.results }
+
+  context "barcode" do
+    let(:filter) { { criteria_type: "barcode", criteria: item.barcode } }
+    it "can find an item by barcode" do
+      expect(subject).to be_kind_of(Sunspot::Search::StandardSearch)
+      expect(results.first).to eq item
+    end
+  end
+
+  it "returns an empty result" do
+    expect(subject).to be_kind_of(described_class::EmptyResults)
+    expect(results).to eq []
   end
 
 end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -1,18 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe SearchItems do
+  include SolrSpecHelper
 
-# I'm not sure how to test this. All attributes of the items match except id, barcode, and timestamps. How it gets different barcodes is beyond me, because this works in feature testing.
-=begin
-  it "can find an item by barcode" do
-    @item = FactoryGirl.create(:item, chron: 'TEST CHRON')
-    @filter = { "criteria_type" => "barcode", "criteria" => @item.barcode }
-p @filter.inspect
-    @items = SearchItems.call(@filter)
-p @items.inspect
-p @item.inspect
-    expect(@item).to eq @items[0]
+  before :all do
+    solr_setup
+    Item.remove_all_from_index!
   end
-=end
+
+  after :all do
+    Item.remove_all_from_index!
+  end
+
+  it "can find an item by barcode" do
+    item = FactoryGirl.create(:item, chron: 'TEST CHRON')
+    Sunspot.index(item)
+    Sunspot.commit
+    search = SearchItems.call(criteria_type: "barcode", criteria: item.barcode)
+    expect(item).to eq search.results.first
+  end
 
 end

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -41,6 +41,33 @@ RSpec.describe SearchItems do
     end
   end
 
+  context "per_page" do
+    let(:item) { FactoryGirl.create(:item, chron: "1") }
+    let(:filter) { { criteria_type: "any", criteria: item.title } }
+
+    it "defaults to 50 per page" do
+      50.times do
+        i = FactoryGirl.create(:item, title: item.title, chron: "2")
+        Sunspot.index(i)
+      end
+      Sunspot.commit
+      expect(subject.total).to eq(51)
+      expect(results.count).to eq(50)
+      expect(results.first).to eq(item)
+    end
+
+    context "1 per page" do
+      it "limits to 1 per page" do
+        filter[:per_page] = 1
+        i = FactoryGirl.create(:item, title: item.title, chron: "2")
+        Sunspot.index(i)
+        Sunspot.commit
+        expect(subject.total).to eq(2)
+        expect(results).to eq([item])
+      end
+    end
+  end
+
   describe "criteria_type" do
     describe "any" do
       let(:filter) { { criteria_type: "any" } }

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -24,15 +24,59 @@ RSpec.describe SearchItems do
 
   context "barcode" do
     let(:filter) { { criteria_type: "barcode", criteria: item.barcode } }
+
     it "can find an item by barcode" do
       expect(subject).to be_kind_of(Sunspot::Search::StandardSearch)
       expect(results.first).to eq item
     end
   end
 
-  it "returns an empty result" do
-    expect(subject).to be_kind_of(described_class::EmptyResults)
-    expect(results).to eq []
+  context "no filter" do
+    let(:filter) { {} }
+
+    it "returns an empty result" do
+      expect(subject).to be_kind_of(described_class::EmptyResults)
+      expect(results).to eq []
+    end
+  end
+
+  describe "criteria_type" do
+    describe "any" do
+      let(:filter) { { criteria_type: "any" } }
+
+      [
+        :barcode,
+        :bib_number,
+        :call_number,
+        :isbn_issn,
+        :title,
+        :author,
+      ].each do |field|
+        it "searches #{field}" do
+          allow(item).to receive(field).and_return("#{field} value")
+          Sunspot.index(item)
+          Sunspot.commit
+          filter[:criteria] = item.send(field)
+          expect(results.first).to eq(item)
+        end
+      end
+
+      it "searches the tray barcode" do
+        item.tray = FactoryGirl.create(:tray)
+        Sunspot.index(item)
+        Sunspot.commit
+        filter[:criteria] = item.tray.barcode
+        expect(results.first).to eq(item)
+      end
+
+      it "searches the shelf barcode" do
+        item.shelf = FactoryGirl.create(:shelf)
+        Sunspot.index(item)
+        Sunspot.commit
+        filter[:criteria] = item.shelf.barcode
+        expect(results.first).to eq(item)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
When we increased the hardcoded limit in SearchItems to 5,000, it increased the number of results being displayed on the item search page to that amount.

This reverts the default back to 50, and updates the BuildRequestData service to request 5,000 per page.

I also added a spec for the SearchItems service so we have complete coverage on that file.