### PR TITLE
AIMS-325: Session timeout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :check_authentication
+  before_action :check_activity
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -16,6 +17,14 @@ class ApplicationController < ActionController::Base
       redirect_to_unauthorized
       return
     end
+  end
+
+  def check_activity
+    if !current_user.present? || IsUserSessionExpired.call(user: current_user)
+      render "users/timed_out"
+      return
+    end
+    update_activity
   end
 
   def redirect_to_sign_in
@@ -36,5 +45,11 @@ class ApplicationController < ActionController::Base
       config_admin = Rails.configuration.admin_user_name
     end
     current_user.admin || (config_admin == current_user.username)
+  end
+
+  def update_activity
+    if current_user
+      current_user.touch(:last_activity_at)
+    end
   end
 end

--- a/app/controllers/simple_cas_controller.rb
+++ b/app/controllers/simple_cas_controller.rb
@@ -1,4 +1,7 @@
 class SimpleCasController < Devise::CasSessionsController
   # Rails <= 3 skip_before_filter :redirect_to_sign_in, only: [:new]
   skip_before_action :check_authentication, only: [:new]
+  skip_before_action :require_no_authentication, only: [:new, :create]
+  skip_before_action :check_activity, only: [:new, :service]
+  before_action :update_activity, only: [:service]
 end

--- a/app/services/is_user_session_expired.rb
+++ b/app/services/is_user_session_expired.rb
@@ -1,0 +1,17 @@
+class IsUserSessionExpired
+  def self.call(user:)
+    new.expired?(user: user)
+  end
+
+  def expired?(user:)
+    if user.last_activity_at.present?
+      timeout = 15.minutes
+      if Rails.configuration.respond_to? :user_timeout
+        timeout = Rails.configuration.user_timeout
+      end
+      Time.now - user.last_activity_at > timeout
+    else
+      true
+    end
+  end
+end

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -4,10 +4,13 @@
     .navbar-header
       = link_to 'Home', root_path, class: 'navbar-brand'
     %ul.nav.navbar-nav.navbar-right
-      %li.status
-        = "Logged in as #{!current_user.nil? ? current_user.username : 'Unknown'}"
+      -if !current_user.nil? && !IsUserSessionExpired.call(user: current_user)
+        %li.status= "Logged in as #{current_user.username}"
       %li
-        = link_to 'Log Out', destroy_user_session_path, method: :delete, class: 'btn btn-default'
+        -if current_user.nil? || IsUserSessionExpired.call(user: current_user)
+          = link_to 'Log In', new_user_session_path, method: :get, class: 'btn btn-default'
+        -else
+          = link_to 'Log Out', destroy_user_session_path, method: :delete, class: 'btn btn-default'
   .collapse.navbar-collapse
     %ul.nav.navbar-nav
       = render 'layouts/navigation_links'

--- a/app/views/users/timed_out.html.haml
+++ b/app/views/users/timed_out.html.haml
@@ -1,0 +1,1 @@
+Your session has timed out. Please click log in to begin a new session.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,9 +44,13 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
+
+  # Configures time before user is logged out due to inactivity
+  config.user_timeout = 24.hours
 end
 
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = 'https://cas.library.nd.edu/cas'
+  config.cas_login_url = 'https://cas.library.nd.edu/cas/login?renew=true'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,6 +51,6 @@ end
 
 Devise.setup do |config|
   # CAS auth
-  config.cas_base_url = 'https://cas.library.nd.edu/cas'
-  config.cas_login_url = 'https://cas.library.nd.edu/cas/login?renew=true'
+  config.cas_base_url = "https://cas.library.nd.edu/cas"
+  config.cas_login_url = "https://cas.library.nd.edu/cas/login?renew=true"
 end

--- a/config/environments/pre_production.rb
+++ b/config/environments/pre_production.rb
@@ -78,9 +78,13 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
+  
+  # Configures time before user is logged out due to inactivity
+  config.user_timeout = 10.hours
 end
 
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = "https://login.nd.edu/cas"
+  config.cas_login_url = 'https://login.nd.edu/cas/login?renew=true'
 end

--- a/config/environments/pre_production.rb
+++ b/config/environments/pre_production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
-  
+
   # Configures time before user is logged out due to inactivity
   config.user_timeout = 10.hours
 end
@@ -86,5 +86,5 @@ end
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = "https://login.nd.edu/cas"
-  config.cas_login_url = 'https://login.nd.edu/cas/login?renew=true'
+  config.cas_login_url = "https://login.nd.edu/cas/login?renew=true"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,5 +86,5 @@ end
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = "https://login.nd.edu/cas"
-  config.cas_login_url = 'https://login.nd.edu/cas/login?renew=true'
+  config.cas_login_url = "https://login.nd.edu/cas/login?renew=true"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,9 +78,13 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
+
+  # Configures time before user is logged out due to inactivity
+  config.user_timeout = 10.hours
 end
 
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = "https://login.nd.edu/cas"
+  config.cas_login_url = 'https://login.nd.edu/cas/login?renew=true'
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,9 +78,13 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
+    
+  # Configures time before user is logged out due to inactivity
+  config.user_timeout = 10.hours
 end
 
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = "https://login.nd.edu/cas"
+  config.cas_login_url = 'https://login.nd.edu/cas/login?renew=true'
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   config.admin_user_name = "mvanneve"
-    
+
   # Configures time before user is logged out due to inactivity
   config.user_timeout = 10.hours
 end
@@ -86,5 +86,5 @@ end
 Devise.setup do |config|
   # CAS auth
   config.cas_base_url = "https://login.nd.edu/cas"
-  config.cas_login_url = 'https://login.nd.edu/cas/login?renew=true'
+  config.cas_login_url = "https://login.nd.edu/cas/login?renew=true"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,9 @@ Rails.application.configure do
 
   # Configures a user as an administrator
   # config.admin_user_name = ""
+
+  # Configures time before user is logged out due to inactivity
+  config.user_timeout = 10.hours
 end
 
 Devise.setup do |config|

--- a/db/migrate/20150904181322_add_users_last_activity.rb
+++ b/db/migrate/20150904181322_add_users_last_activity.rb
@@ -1,0 +1,5 @@
+class AddUsersLastActivity < ActiveRecord::Migration
+  def change
+    add_column :users, :last_activity_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150901194225) do
+ActiveRecord::Schema.define(version: 20150904181322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 20150901194225) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "admin",              default: false, null: false
+    t.datetime "last_activity_at"
   end
 
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
     sequence(:username) { |n| "hallett#{n}" }
+    last_activity_at { Time.now }
   end
-
 end

--- a/spec/services/is_user_session_expired_spec.rb
+++ b/spec/services/is_user_session_expired_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe IsUserSessionExpired do
+  let(:user) { instance_double(User) }
+
+  it "calls expired? with the given user" do
+    expect_any_instance_of(IsUserSessionExpired).to receive("expired?")
+    described_class.call(user: user)
+  end
+
+  describe "expired?" do
+    it "returns true if last activity exceeds the time limit" do
+      allow(Rails.configuration).to receive(:user_timeout).and_return(1.days)
+      allow(user).to receive(:last_activity_at).and_return(Time.now - 2.days)
+      expect(subject.expired?(user: user)).to eq(true)
+    end
+
+    it "returns false if last activity does not exceed the time limit" do
+      allow(Rails.configuration).to receive(:user_timeout).and_return(1.days)
+      allow(user).to receive(:last_activity_at).and_return(Time.now)
+      expect(subject.expired?(user: user)).to eq(false)
+    end
+
+    it "returns false if there is no last activity" do
+      allow(user).to receive(:last_activity_at).and_return(nil)
+      expect(subject.expired?(user: user)).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Why: User sessions remain valid for indefinite amount of time, causing security issues.
How:  User sessions will now expire. Did not use built in devise timeoutable method since it doesn't allow customizing the timed out page. Created our own expiration calculation which will now render a timed out page that forces the user to click login. By default, will timeout after 10 hours of inactivity for prod/preprod/staging. This should cause a login once per day if they're active in it all day. For dev using 24 hours. These can be changed in configs.