### PR TITLE
AIMS-325: Session timeout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
 
   def check_activity
     if !current_user.present? || IsUserSessionExpired.call(user: current_user)
+      sign_out
       render "users/timed_out"
       return
     end


### PR DESCRIPTION
Discovered we still had a problem with it retaining the previous app session even with the renew call. Added a sign_out call and it seems to now be fully functional.