### PR TITLE
AIMS-331:  Empty batch bug

### DIFF
--- a/app/controllers/bins_controller.rb
+++ b/app/controllers/bins_controller.rb
@@ -10,11 +10,16 @@ class BinsController < ApplicationController
 
   def remove
     @match = Match.find(params[:match_id])
-    bin_id = @match.bin.id
+    item = @match.item
+    bin = @match.bin
 
     ProcessMatch.call(match: @match, user: current_user)
 
-    redirect_to show_bin_path(:id => bin_id)
+    unless bin.matches.where(item: item).empty?
+      flash[:warning] = "Processed transaction #{@match.request.trans}. There are remaining requests for the item."
+    end
+
+    redirect_to show_bin_path(:id => bin.id)
   end
 
 end

--- a/app/controllers/bins_controller.rb
+++ b/app/controllers/bins_controller.rb
@@ -1,5 +1,4 @@
 class BinsController < ApplicationController
-
   def index
     @bins = Bin.includes(:matches).where.not(matches: { id: nil })
   end
@@ -19,7 +18,6 @@ class BinsController < ApplicationController
       flash[:warning] = "Processed transaction #{@match.request.trans}. There are remaining requests for the item."
     end
 
-    redirect_to show_bin_path(:id => bin.id)
+    redirect_to show_bin_path(id: bin.id)
   end
-
 end

--- a/app/services/process_match.rb
+++ b/app/services/process_match.rb
@@ -39,10 +39,13 @@ class ProcessMatch
   end
 
   def dissociate_bin
-    ActivityLogger.dissociate_item_and_bin(item: item, bin: item.bin, user: user)
-
-    item.update!(bin: nil)
+    bin = match.bin
     match.update!(bin: nil)
+    # If there are no remaining matches for this item and bin, dissociate the item/bin
+    if bin.matches.where(item: item).empty?
+      ActivityLogger.dissociate_item_and_bin(item: item, bin: item.bin, user: user)
+      item.update!(bin: nil)
+    end
   end
 
   def scan_send

--- a/app/views/bins/show.html.haml
+++ b/app/views/bins/show.html.haml
@@ -1,4 +1,4 @@
-- if @bin.items.blank?
+- if @bin.matches.blank?
   = "Bin #{@bin.barcode} is empty."
 - else
   = @bin.barcode

--- a/lib/tasks/annex.rake
+++ b/lib/tasks/annex.rake
@@ -8,30 +8,28 @@ namespace :annex do
     logger.info("[annex:get_active_requests] #{message}")
   end
 
+  # Matches associated with AIMS-331
+  def broken_matches
+    Match.
+      where.not(bin_id: nil).
+      where('"matches"."processed" != \'completed\'').
+      joins(:request).where(requests: { del_type: "scan" }).
+      joins(:item).where('"items"."bin_id" IS NULL OR "items"."bin_id" != "matches"."bin_id"').
+      order(:bin_id)
+  end
+
   # Due to bug AIMS-331, some matches for scan requests and their related items entered
   # into an inconsistent state where the match remained as unprocessed in a bin but the
-  # item was restocked and dissociated from the bin. This is a one time fix for any data
-  # remaining in that state. It will do the following:
+  # item was restocked and dissociated from the bin. This task will dump the associated
+  # matches that need to be corrected to files as follows:
   #
-  # For each match in this state:
-  #   Log a scan activity
-  #   Change the match status to completed
-  #   Dissociate the match and bin
+  # Raw match data that was affected will be output to fixed_matches.txt
+  # Formatted data similar to the "Process Batch" view will be output to fixed_matches_view.txt
   #
-  # A pre-change copy of the match data that was affected will be output to fixed_matches.txt
-  # A pre-change copy of the match data similar to the "Process Bin" view will be output to
-  # fixed_matches_view.txt
-  #
-  desc "Fix matches associated with AIMS-331"
-  task fix_aims331_matches: :environment do
+  desc "Dump matches associated with AIMS-331"
+  task dump_aims331_matches: :environment do
     Airbrake.configuration.rescue_rake_exceptions = true
 
-    broken_matches = Match.
-                       where.not(bin_id: nil).
-                       where('"matches"."processed" != \'completed\'').
-                       joins(:request).where(requests: { del_type: "scan" }).
-                       joins(:item).where('"items"."bin_id" IS NULL OR "items"."bin_id" != "matches"."bin_id"').
-                       order(:bin_id)
     view_file = File.open("fixed_matches_view.csv", "w")
     match_file = File.open("fixed_matches.txt", "w")
 
@@ -40,17 +38,32 @@ namespace :annex do
       view_file << "\"#{match.bin_id}\",\"#{match.batch.user.username}\",\"#{match.item.barcode}\",\"#{match.request.trans}\",\"#{match.item.title}\",\"#{match.item.author}\""
       view_file << "\n"
       match_file << match.attributes << "\n"
+    end
+    view_file.close
+    match_file.close
+  end
 
+  # Due to bug AIMS-331, some matches for scan requests and their related items entered
+  # into an inconsistent state where the match remained as unprocessed in a bin but the
+  # item was restocked and dissociated from the bin. This is a one time fix for any data
+  # remaining in that state. It will do the following:
+  #
+  # For each match in this state:
+  #   Log a scan activity for the item/request
+  #   Change the match status to completed
+  #   Dissociate the match and bin
+  #
+  desc "Fix matches associated with AIMS-331"
+  task fix_aims331_matches: :environment do
+    Airbrake.configuration.rescue_rake_exceptions = true
+
+    broken_matches.each do |match|
       data = { item: match.item.attributes, request: match.request.attributes, user: nil }
       last_time_in_bin = ActivityLog.where(action: "DissociatedItemAndBin").where("data->'item'->>'id' = '#{match.item.id}'").where("data->'bin'->>'id' = '#{match.bin.id}'").maximum(:created_at)
-
       ActiveRecord::Base.transaction do
         ActivityLog.create!(action: "ScannedItem", data: data, action_timestamp: last_time_in_bin, username: "system", user_id: "system")
         match.update!(bin: nil, processed: "completed")
       end
     end
-    view_file.close
-    match_file.close
-    nil
   end
 end

--- a/spec/controllers/bins_controller_spec.rb
+++ b/spec/controllers/bins_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe BinsController, type: :controller do
     end
 
     it "redirects back to show" do
-      expect(subject).to redirect_to show_bin_path(:id => bin.id)
+      expect(subject).to redirect_to show_bin_path(id: bin.id)
     end
   end
 end

--- a/spec/controllers/bins_controller_spec.rb
+++ b/spec/controllers/bins_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe BinsController, type: :controller do
+  let(:shelf) { FactoryGirl.create(:shelf) }
+  let(:tray) { FactoryGirl.create(:tray, shelf: shelf) }
+  let(:item) { FactoryGirl.create(:item, tray: tray, thickness: 1) }
+  let(:bin) { FactoryGirl.create(:bin, items: [item]) }
+  let(:match) { FactoryGirl.create(:match, item: item, bin: bin, request: request) }
+  let(:user) { FactoryGirl.create(:user, admin: true) }
+  let(:request) { FactoryGirl.create(:request, del_type: "loan") }
+
+  before(:each) do
+    sign_in(user)
+  end
+
+  describe "remove" do
+    let(:subject) { post :remove, match_id: match.id }
+
+    it "uses ProcessMatch" do
+      expect(ProcessMatch).to receive(:call).with(match: match, user: user)
+      subject
+    end
+
+    it "flashes a message when there are remaining matches associated with the item" do
+      request2 = FactoryGirl.create(:request, del_type: "loan")
+      FactoryGirl.create(:match, item: item, bin: bin, request: request2)
+      subject
+      expect(flash[:warning]).to be_present
+    end
+
+    it "redirects back to show" do
+      expect(subject).to redirect_to show_bin_path(:id => bin.id)
+    end
+  end
+end

--- a/spec/services/process_match_spec.rb
+++ b/spec/services/process_match_spec.rb
@@ -15,11 +15,43 @@ RSpec.describe ProcessMatch do
     expect(subject).to eq(true)
   end
 
-  it "dissociates the bin and logs the activity" do
-    expect(ActivityLogger).to receive(:dissociate_item_and_bin).with(item: item, bin: bin, user: user)
-    subject
-    expect(match.bin).to be_nil
-    expect(item.bin).to be_nil
+  context "when there are no remaining matches for the associated item" do
+    it "dissociates the bin from the associated item" do
+      subject
+      expect(item.bin).to be_nil
+    end
+
+    it "logs a dissociation of bin and item" do
+      expect(ActivityLogger).to receive(:dissociate_item_and_bin).with(item: item, bin: bin, user: user)
+      subject
+    end
+
+    it "dissociates the bin from the match that was processed" do
+      subject
+      expect(item.bin).to be_nil
+    end
+  end
+
+  context "when there are remaining matches for the associated item" do
+    before(:each) do
+      request2 = FactoryGirl.create(:request, del_type: "loan")
+      FactoryGirl.create(:match, item: item, bin: bin, request: request2)
+    end
+
+    it "doesn't dissociate the bin and item" do
+      subject
+      expect(item.bin).to eq(bin)
+    end
+
+    it "doesn't log a dissociation of bin and item" do
+      expect(ActivityLogger).not_to receive(:dissociate_item_and_bin).with(item: item, bin: bin, user: user)
+      subject
+    end
+
+    it "dissociates the bin from the match that was processed" do
+      subject
+      expect(item.bin).to eq(bin)
+    end
   end
 
   it "ships the item" do


### PR DESCRIPTION
Why: If multiple scan requests for a single item would get batched, the user would only be able to process one of them.
How: The application was immediately dissociating an item from a bin as soon as the first scan was processed, which prevented the view from showing the remaining matches. Changed the app to only dissociate an item from a bin once all requests in that bin for that item have been fulfilled. Now, when they process one request, it will flash a message warning that there are remaining requests for that item. In addition, I created a rake task that we can use to spot check and clean up the data when we deploy.