### PR TITLE
AIMS-336: Add process details

### DIFF
--- a/app/views/bins/show.html.haml
+++ b/app/views/bins/show.html.haml
@@ -11,6 +11,8 @@
         %th= 'Transaction'
         %th= 'Title'
         %th= 'Author'
+        %th= 'Article Title'
+        %th= 'Description'
         %th= ''
     %tbody
       - @bin.matches.each do |match|
@@ -20,6 +22,8 @@
           %td= match.request.trans
           %td= match.item.title
           %td= match.item.author
+          %td= match.request.article_title
+          %td= match.request.description
           %td
             = form_tag bin_remove_path do |f|
               = hidden_field_tag :match_id, match.id

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -27,7 +27,7 @@
     #batches.collapse
       %a.list-group-item{ :href => batches_path } Create Batch
       %a.list-group-item{ :href => retrieve_batch_path } Retrieve Batch
-      %a.list-group-item{ :href => bins_path } Process Batch
+      %a.list-group-item{ :href => bins_path } Process Bins
       %a.list-group-item{ :href => current_batch_path } View Current Batch
       %a.list-group-item{ :href => view_processed_batches_path }
         View Processed Batches


### PR DESCRIPTION
Why: Now that they are able to process requests directly in the Annex, they need more information on the request to be displayed when processing a bin.
How: Added Article Title and Description. Description is a packed field that contains things like pages, volume, etc. We also decided to change "Process Batch" to "Process Bin". The view linked to by "Process Batch" is actually showing a list of bins. The desired behavior for the workflow is to show all bins, not just the bins associated with that user's current batch. So we're renaming the menu option to match so that there's less confusion for future users/devs.