### PR TITLE
AIMS-219: Cleanup "not found" items that are not associated with a tray

### DIFF
--- a/app/services/destroy_item.rb
+++ b/app/services/destroy_item.rb
@@ -2,7 +2,7 @@ class DestroyItem
   attr_reader :item, :user
 
   def self.call(item, user)
-    new(item, user).destroy
+    new(item, user).destroy!
   end
 
   def initialize(item, user)
@@ -10,9 +10,9 @@ class DestroyItem
     @user = user
   end
 
-  def destroy
-    status = item.destroy!
-    ActivityLogger.destroy_item(item: item, user: user)
-    status
+  def destroy!
+    destroyed = item.destroy!
+    ActivityLogger.destroy_item(item: item, user: user) if destroyed
+    destroyed
   end
 end

--- a/lib/tasks/annex.rake
+++ b/lib/tasks/annex.rake
@@ -8,7 +8,7 @@ namespace :annex do
     logger.info("[annex:get_active_requests] #{message}")
   end
 
-  desc "Destroys invalid items. These are typically created due to the optimistic way that items are created when scanning."
+  desc "Destroys items created by inaccurate barcode scans or items that were not meant for annex."
   task destroy_invalid_items: :environment do
     require 'csv'
     require Rails.root.join("lib", "tasks", "services", "destroy_invalid_items.rb").to_s

--- a/lib/tasks/annex.rake
+++ b/lib/tasks/annex.rake
@@ -8,6 +8,42 @@ namespace :annex do
     logger.info("[annex:get_active_requests] #{message}")
   end
 
+  desc "Destroys invalid items. These are typically created due to the optimistic way that items are created when scanning."
+  task destroy_invalid_items: :environment do
+    require 'csv'
+    require Rails.root.join("lib", "tasks", "services", "destroy_invalid_items.rb").to_s
+
+    Airbrake.configuration.rescue_rake_exceptions = true
+    logger = Logger.new(STDOUT)
+
+    system_user = OpenStruct.new({ user_id: nil, username: "system" })
+    results = Lib::Tasks::Services::DestroyInvalidItems.call(user: system_user)
+    timestamp = (DateTime.now.to_f * 1000).to_i
+    item_attrs = Item.new.attributes.map { |k, v| k }
+
+    if results[:destroyed].present?
+      destroyed_file = CSV.open("destroyed_items_#{timestamp}.csv", "w")
+      destroyed_file << item_attrs
+      results[:destroyed].each do |item|
+        destroyed_file << item_attrs.map { |k| item[k] }
+      end
+      destroyed_file.close
+      print "Wrote destroyed items to #{destroyed_file.path}\n"
+    else
+      print "No items were destroyed.\n"
+    end
+
+    if results[:failed].present?
+      failed_file = CSV.open("failed_items_#{timestamp}.csv", "w")
+      failed_file << item_attrs
+      results[:failed].each do |item|
+        failed_file << item_attrs.map { |k| item[k] }
+      end
+      failed_file.close
+      print "Wrote failed items to #{failed_file.path}\n"
+    end
+  end
+
   # Matches associated with AIMS-331
   def broken_matches
     Match.

--- a/lib/tasks/services/destroy_invalid_items.rb
+++ b/lib/tasks/services/destroy_invalid_items.rb
@@ -8,19 +8,19 @@ module Lib
       class DestroyInvalidItems
         attr_reader :user
 
-        def self.call(user: user)
+        def self.call(user:)
           new(user: user).destroy
         end
 
-        def initialize(user: user)
+        def initialize(user:)
           @user = user
         end
 
         def destroy
           items = Item.
-            where(tray_id: nil).
-            where("metadata_updated_at < ?", 1.hour.ago).
-            where(metadata_status: ["not_found", "not_for_annex"])
+                    where(tray_id: nil).
+                    where("metadata_updated_at < ?", 1.hour.ago).
+                    where(metadata_status: ["not_found", "not_for_annex"])
           destroyed = []
           failures = []
           items.each do |item|

--- a/lib/tasks/services/destroy_invalid_items.rb
+++ b/lib/tasks/services/destroy_invalid_items.rb
@@ -18,9 +18,9 @@ module Lib
 
         def destroy
           items = Item.
-                    where(tray_id: nil).
-                    where("metadata_updated_at < ?", 1.hour.ago).
-                    where(metadata_status: ["not_found", "not_for_annex"])
+                  where(tray_id: nil).
+                  where("metadata_updated_at < ?", 1.hour.ago).
+                  where(metadata_status: ["not_found", "not_for_annex"])
           destroyed = []
           failures = []
           items.each do |item|

--- a/lib/tasks/services/destroy_invalid_items.rb
+++ b/lib/tasks/services/destroy_invalid_items.rb
@@ -1,0 +1,39 @@
+# The system currently performs an optimistic creation of an item
+# using whatever it's given as a barcode. This service was
+# specifically added to clean up invalid items created due to things
+# like receiving junk barcodes from the scanner.
+module Lib
+  module Tasks
+    module Services
+      class DestroyInvalidItems
+        attr_reader :user
+
+        def self.call(user: user)
+          new(user: user).destroy
+        end
+
+        def initialize(user: user)
+          @user = user
+        end
+
+        def destroy
+          items = Item.
+            where(tray_id: nil).
+            where("metadata_updated_at < ?", 1.hour.ago).
+            where(metadata_status: ["not_found", "not_for_annex"])
+          destroyed = []
+          failures = []
+          items.each do |item|
+            success = DestroyItem.call(item, user)
+            if success
+              destroyed << item
+            else
+              failures << item
+            end
+          end
+          { destroyed: destroyed, failed: failures }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/destroy_item_spec.rb
+++ b/spec/services/destroy_item_spec.rb
@@ -5,7 +5,7 @@ describe "DestroyItem" do
   let(:user) { FactoryGirl.create(:user) }
   subject { DestroyItem.call(item, user) }
 
-  describe "#destroy" do
+  describe "#destroy!" do
     it "deletes one request" do
       item
       expect { subject }.to change { Item.count }.from(1).to(0)
@@ -17,6 +17,12 @@ describe "DestroyItem" do
 
     it "logs the activity" do
       expect(ActivityLogger).to receive(:destroy_item).with(item: item, user: user).and_call_original
+      subject
+    end
+
+    it "does not log the activity if it fails" do
+      allow_any_instance_of(Item).to receive(:destroy!).and_return(false)
+      expect(ActivityLogger).not_to receive(:destroy_item)
       subject
     end
   end


### PR DESCRIPTION
Why: A lot of items have been added to the system using junk data from the barcode scanner due to the way we optimistically create an item, then look up its info later. This is getting in the way of querying/viewing valid items.
How: Created a rake task to destroy all items that are not assigned to a tray and are either "not found" or "not marked for annex". This task will be run adhoc to clean up the data (such as during our next deploy). Future development such as input validation should begin to prevent this data from being created, so a cron job is likely not needed, but if we do end up creating one, it can just use this rake task.