### PR TITLE
AIMS-263: Remove item from bin

### DIFF
--- a/app/views/bins/show.html.haml
+++ b/app/views/bins/show.html.haml
@@ -32,7 +32,7 @@
             = form_tag bin_remove_path do |f|
               = hidden_field_tag :match_id, match.id
               .actions
-                = submit_tag 'Remove', class: 'btn btn-primary'
+                = submit_tag 'Skip', class: 'btn btn-warning'
   :javascript
     $(document).ready(function() {
       window.table = $('#matches').DataTable();


### PR DESCRIPTION
Changing appearance of the remove button. Will now say Skip and look like the Skip button used in batch retrieval. It's a similar operation that the user is familiar with, so they should better understand what this action will do at this point in the workflow.