### PR TITLE
Aims 340 add bin info to item details

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -35,7 +35,6 @@ class Item < ActiveRecord::Base
   has_many :requests, through: :matches
   has_many :batches, through: :matches
   has_many :filled_requests, class_name: "Request", foreign_key: "item_id"
-  has_many :activity_logs, class_name: "ActivityLog", foreign_key: "object_item_id"
 
   searchable do
     text :barcode

--- a/app/presenters/item_view_presenter.rb
+++ b/app/presenters/item_view_presenter.rb
@@ -6,4 +6,19 @@ class ItemViewPresenter < Presenter
       super
     end
   end
+
+  def location
+    case @object.status
+    when "stocked"
+      @object.tray.barcode
+    when "unstocked"
+      if @object.bin
+        @object.bin.barcode
+      else
+        "Staging"
+      end
+    when "shipped"
+      "Shipped - Not In Annex"
+    end
+  end
 end

--- a/app/views/items/item_detail.html.haml
+++ b/app/views/items/item_detail.html.haml
@@ -57,6 +57,10 @@
             %td
               %strong= "Tray Number:"
             %td= (@item.tray.nil? ? 'STAGING' : @item.tray.barcode)
+          %tr
+            %td
+              %strong= "Location:"
+            %td= @item.location
   %div.panel.panel-success
     %div.panel-heading
       %h3.panel-title= "Item History"
@@ -97,4 +101,3 @@
               %td= record.data['request']['trans']
               %td= record.action_timestamp.strftime("%m-%d-%Y %I:%M%p")
               %td= record.username
-             

--- a/spec/presenters/item_view_presenter_spec.rb
+++ b/spec/presenters/item_view_presenter_spec.rb
@@ -1,27 +1,58 @@
 require "rails_helper"
 
 RSpec.describe ItemViewPresenter do
-  let(:item) { FactoryGirl.build(:item) }
-  let(:item2) { FactoryGirl.build(:item) }
-  let!(:issue1) { FactoryGirl.create(:issue, issue_type: "not_for_annex", barcode: item.barcode) }
-  let!(:issue2) { FactoryGirl.create(:issue, issue_type: "not_found", barcode: item.barcode) }
+  let(:shelf) { FactoryGirl.create(:shelf) }
+  let(:tray) { FactoryGirl.create(:tray, shelf: shelf) }
+  let(:user) { FactoryGirl.create(:user) }
+
+  let(:item1) { FactoryGirl.build(:item, tray: tray, status: 1) }
+  let(:item2) { FactoryGirl.build(:item, tray: tray, status: 0) }
+  let(:item3) { FactoryGirl.build(:item, tray: tray, status: 2) }
+  let(:item4) { FactoryGirl.build(:item, tray: tray, status: 0) }
+  let(:item5) { FactoryGirl.build(:item, tray: tray, status: 1) }
+  let(:bin) { FactoryGirl.create(:bin, items: [item5]) }
+  let!(:issue1) { FactoryGirl.create(:issue, issue_type: "not_for_annex", barcode: item1.barcode) }
+  let!(:issue2) { FactoryGirl.create(:issue, issue_type: "not_found", barcode: item2.barcode) }
 
   context "no issues for item" do
     it "returns the plain status value" do
-      item_presenter = described_class.new(item2)
-      expect(item_presenter.status).to eq "stocked"
+      item_presenter = described_class.new(item3)
+      expect(item_presenter.status).to eq "shipped"
     end
   end
 
   context "issues for item" do
     it "returns the modified status value" do
-      item_presenter = described_class.new(item)
-      expect(item_presenter.status).to eq "stocked (on issue list)"
+      item_presenter = described_class.new(item1)
+      expect(item_presenter.status).to eq "unstocked (on issue list)"
     end
 
     it "returns the modified status value when there are multiple issues" do
-      item_presenter = described_class.new(item)
+      item_presenter = described_class.new(item2)
       expect(item_presenter.status).to eq "stocked (on issue list)"
+    end
+  end
+
+  describe "#location" do
+    it "returns tray barcode when item is stocked" do
+      item_presenter = described_class.new(item4)
+      expect(item_presenter.location).to eq "#{tray.barcode}"
+    end
+
+    it "returns bin barcode when item is unstocked and in a bin" do
+      bin
+      item_presenter = described_class.new(item5)
+      expect(item_presenter.location).to eq "#{bin.barcode}"
+    end
+
+    it "returns staging when item is unstocked and not in a bin" do
+      item_presenter = described_class.new(item1)
+      expect(item_presenter.location).to eq "Staging"
+    end
+
+    it "returns shipped message when item is shipped" do
+      item_presenter = described_class.new(item3)
+      expect(item_presenter.location).to eq "Shipped - Not In Annex"
     end
   end
 end


### PR DESCRIPTION
What: Added information to the item detail page that indicates the current location of the item.
Why: It had been difficult to determine the current status of an item if it had been retrieved for batch processing and was sitting in a bin awaiting processing, having been shipped, or having returned from a loan awaiting restocking. This information will help to alleviate that problem.
How: Created a new method in the item view presenter that returns location strings and added that information to the item detail view.