### PR TITLE
Updates for users page AIMS-335

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,12 +17,22 @@ class UsersController < ApplicationController
 
   def update
     user_id = params["user_id"]
-    # If the checkbox was false on submit, the admin param will be null :(
-    admin = params["admin"] || false
     user = User.find(user_id)
     if user
-      user.admin = admin
+      # If the admin was selected, then user is set to admin and otherwise to worker
+      if params["user_type"] == "admin"
+        user.admin = true
+        user.worker = false
+      # If the worker was selected, then user is set to worker and otherwise to disabled
+      elsif params["user_type"] == "worker"
+        user.admin = false
+        user.worker = true
+      else
+        user.admin = false
+        user.worker = false
+      end
       user.save!
+      flash[:notice] = "#{user.username}'s status is updated to #{params["user_type"]}."
     end
     redirect_to users_path
   end

--- a/app/services/get_user_type.rb
+++ b/app/services/get_user_type.rb
@@ -1,0 +1,11 @@
+module GetUserType
+  def self.call(user)
+    if user.admin == true && user.worker == false
+      return "admin"
+    elsif user.admin == false && user.worker == true
+      return "worker"
+    elsif user.admin == false && user.worker == false
+      return "disabled"
+    end
+  end
+end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -26,16 +26,12 @@
           %td= user.last_sign_in_at
 
           - if current_user == user
-            %td= 'admin'
+            %td= GetUserType.call(user)
             %td
           - else
             = form_tag update_users_path, method: "put" do |f|
-              - if user.admin == true
-                %td= select_tag :user_type, options_for_select(["admin", "worker", "disabled"], "admin")
-              - elsif user.worker == true
-                %td= select_tag :user_type, options_for_select(["admin", "worker", "disabled"], "worker")
-              - else
-                %td= select_tag :user_type, options_for_select(["admin", "worker", "disabled"], "disabled")
+              %td= select_tag :user_type, options_for_select(["admin", |
+                        "worker", "disabled"], GetUserType.call(user)) |
               %td
                 = hidden_field_tag :user_id, user.id
                 .actions

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -16,7 +16,7 @@
         %th= 'User'
         %th= 'Sign in Count'
         %th= 'Last Sign In'
-        %th= 'Admin?'
+        %th= 'User type'
         %th
     %tbody
       - @users.each do |user|
@@ -24,12 +24,22 @@
           %td= user.username
           %td= user.sign_in_count
           %td= user.last_sign_in_at
-          = form_tag update_users_path, method: "put" do |f|
-            %td= check_box_tag "admin", "true", user.admin
+
+          - if current_user == user
+            %td= 'admin'
             %td
-              = hidden_field_tag :user_id, user.id
-              .actions
-                = submit_tag 'Save', class: 'btn btn-primary', id: "user-#{user.id}"
+          - else
+            = form_tag update_users_path, method: "put" do |f|
+              - if user.admin == true
+                %td= select_tag :user_type, options_for_select(["admin", "worker", "disabled"], "admin")
+              - elsif user.worker == true
+                %td= select_tag :user_type, options_for_select(["admin", "worker", "disabled"], "worker")
+              - else
+                %td= select_tag :user_type, options_for_select(["admin", "worker", "disabled"], "disabled")
+              %td
+                = hidden_field_tag :user_id, user.id
+                .actions
+                  = submit_tag 'Update', class: 'btn btn-primary', id: "user-#{user.id}"
     :javascript
         $(document).ready(function() {
           window.table = $('#users').DataTable();

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -8,18 +8,27 @@ RSpec.describe UsersController, type: :controller do
   end
 
   describe "PUT update" do
-    it "sets admin to the value given" do
+    it "sets admin to the value given for user type" do
       expect_any_instance_of(User).to receive(:admin=).with(true)
-      put :update, user_id: 1, admin: true
+      expect_any_instance_of(User).to receive(:worker=).with(false)
+      put :update, user_id: 1, user_type: "admin"
     end
 
-    it "sets admin to the value given" do
+    it "sets admin to the value given for user type" do
       expect_any_instance_of(User).to receive(:admin=).with(false)
-      put :update, user_id: 1, admin: false
+      expect_any_instance_of(User).to receive(:worker=).with(true)
+      put :update, user_id: 1, user_type: "worker"
     end
 
-    it "sets admin to false if no value given" do
+    it "sets admin to the value given for user type" do
       expect_any_instance_of(User).to receive(:admin=).with(false)
+      expect_any_instance_of(User).to receive(:worker=).with(false)
+      put :update, user_id: 1, user_type: "disabled"
+    end
+
+    it "sets admin to false if no value given for user type" do
+      expect_any_instance_of(User).to receive(:admin=).with(false)
+      expect_any_instance_of(User).to receive(:worker=).with(false)
       put :update, user_id: 1
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -8,25 +8,25 @@ RSpec.describe UsersController, type: :controller do
   end
 
   describe "PUT update" do
-    it "sets admin to the value given for user type" do
+    it "sets admin and worker properties to the correct values for user type 'admin'" do
       expect_any_instance_of(User).to receive(:admin=).with(true)
       expect_any_instance_of(User).to receive(:worker=).with(false)
       put :update, user_id: 1, user_type: "admin"
     end
 
-    it "sets admin to the value given for user type" do
+    it "sets admin and worker properties to the correct values for user type 'worker'" do
       expect_any_instance_of(User).to receive(:admin=).with(false)
       expect_any_instance_of(User).to receive(:worker=).with(true)
       put :update, user_id: 1, user_type: "worker"
     end
 
-    it "sets admin to the value given for user type" do
+    it "sets admin and worker properties to the correct values for user type 'disabled'" do
       expect_any_instance_of(User).to receive(:admin=).with(false)
       expect_any_instance_of(User).to receive(:worker=).with(false)
       put :update, user_id: 1, user_type: "disabled"
     end
 
-    it "sets admin to false if no value given for user type" do
+    it "sets admin and worker properties to false if no value given for user type" do
       expect_any_instance_of(User).to receive(:admin=).with(false)
       expect_any_instance_of(User).to receive(:worker=).with(false)
       put :update, user_id: 1

--- a/spec/services/get_user_type_spec.rb
+++ b/spec/services/get_user_type_spec.rb
@@ -3,35 +3,35 @@ require 'rails_helper'
 RSpec.describe GetUserType do
   it "returns 'admin' for an user with admin type" do
     user = FactoryGirl.create(:user, id: 1, admin: true)
-    expect(GetUserType.call(user)).to eq('admin')
-    expect(GetUserType.call(user)).to_not eq('worker')
+    expect(GetUserType.call(user)).to eq("admin")
+    expect(GetUserType.call(user)).to_not eq("worker")
   end
 
   it "returns 'worker' for an user with worker type" do
     user = FactoryGirl.create(:user, id: 1, worker: true)
-    expect(GetUserType.call(user)).to eq('worker')
-    expect(GetUserType.call(user)).to_not eq('admin')
+    expect(GetUserType.call(user)).to eq("worker")
+    expect(GetUserType.call(user)).to_not eq("admin")
   end
 
   it "returns 'disabled' for an user without any type" do
     user = FactoryGirl.create(:user, id: 1)
-    expect(GetUserType.call(user)).to eq('disabled')
-    expect(GetUserType.call(user)).to_not eq('worker')
-    expect(GetUserType.call(user)).to_not eq('admin')
+    expect(GetUserType.call(user)).to eq("disabled")
+    expect(GetUserType.call(user)).to_not eq("worker")
+    expect(GetUserType.call(user)).to_not eq("admin")
   end
 
   it "returns 'disabled' for an user without admin and worker types" do
     user = FactoryGirl.create(:user, id: 1, admin: false, worker: false)
-    expect(GetUserType.call(user)).to eq('disabled')
-    expect(GetUserType.call(user)).to_not eq('worker')
-    expect(GetUserType.call(user)).to_not eq('admin')
+    expect(GetUserType.call(user)).to eq("disabled")
+    expect(GetUserType.call(user)).to_not eq("worker")
+    expect(GetUserType.call(user)).to_not eq("admin")
   end
 
   it "returns 'nil' for an user with both admin and worker types" do
     user = FactoryGirl.create(:user, id: 1, admin: true, worker: true)
     expect(GetUserType.call(user)).to eq(nil)
-    expect(GetUserType.call(user)).to_not eq('admin')
-    expect(GetUserType.call(user)).to_not eq('worker')
-    expect(GetUserType.call(user)).to_not eq('disabled')
+    expect(GetUserType.call(user)).to_not eq("admin")
+    expect(GetUserType.call(user)).to_not eq("worker")
+    expect(GetUserType.call(user)).to_not eq("disabled")
   end
 end

--- a/spec/services/get_user_type_spec.rb
+++ b/spec/services/get_user_type_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe GetUserType do
+  it "returns 'admin' for an user with admin type" do
+    user = FactoryGirl.create(:user, id: 1, admin: true)
+    expect(GetUserType.call(user)).to eq('admin')
+    expect(GetUserType.call(user)).to_not eq('worker')
+  end
+
+  it "returns 'worker' for an user with worker type" do
+    user = FactoryGirl.create(:user, id: 1, worker: true)
+    expect(GetUserType.call(user)).to eq('worker')
+    expect(GetUserType.call(user)).to_not eq('admin')
+  end
+
+  it "returns 'disabled' for an user without any type" do
+    user = FactoryGirl.create(:user, id: 1)
+    expect(GetUserType.call(user)).to eq('disabled')
+    expect(GetUserType.call(user)).to_not eq('worker')
+    expect(GetUserType.call(user)).to_not eq('admin')
+  end
+
+  it "returns 'disabled' for an user without admin and worker types" do
+    user = FactoryGirl.create(:user, id: 1, admin: false, worker: false)
+    expect(GetUserType.call(user)).to eq('disabled')
+    expect(GetUserType.call(user)).to_not eq('worker')
+    expect(GetUserType.call(user)).to_not eq('admin')
+  end
+
+  it "returns 'nil' for an user with both admin and worker types" do
+    user = FactoryGirl.create(:user, id: 1, admin: true, worker: true)
+    expect(GetUserType.call(user)).to eq(nil)
+    expect(GetUserType.call(user)).to_not eq('admin')
+    expect(GetUserType.call(user)).to_not eq('worker')
+    expect(GetUserType.call(user)).to_not eq('disabled')
+  end
+end


### PR DESCRIPTION
Admins can now update the type of user for existing users in the database via the users page, which now has select options for user types and update button. Every time the user type is changed, there will be a notification on top of the page that will give details of the update. Also the current user is disabled to change own user type due to a safety requirement.