### PR TITLE
AIMS-354: Added validation for count of items in the tray

### DIFF
--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -233,7 +233,7 @@ class TraysController < ApplicationController
 
     if !tray_count.nil?
       if tray_count.to_i != items.count
-        flash.now[:error] = "Manual and System Tray counts don't match! Try again."
+        flash.now[:error] = I18n.t("trays.items_count_not_match")
       else
         redirect_to trays_items_path
       end

--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -228,8 +228,8 @@ class TraysController < ApplicationController
 
   def count_item
     @tray = Tray.find(params[:id])
-    tray_count = (params[:tray_count])
-    items = Item.select {|item| item.tray_id == @tray.id}
+    tray_count = params[:tray_count]
+    items = Item.select { |item| item.tray_id == @tray.id }
 
     if !tray_count.nil?
       if tray_count.to_i != items.count

--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -225,4 +225,18 @@ class TraysController < ApplicationController
       redirect_to show_tray_item_path(id: tray.id)
     end
   end
+
+  def count_item
+    @tray = Tray.find(params[:id])
+    tray_count = (params[:tray_count])
+    items = Item.select {|item| item.tray_id == @tray.id}
+
+    if !tray_count.nil?
+      if tray_count.to_i != items.count
+        flash.now[:error] = "Manual and System Tray counts don't match! Try again."
+      else
+        redirect_to trays_items_path
+      end
+    end
+  end
 end

--- a/app/views/trays/count_item.html.haml
+++ b/app/views/trays/count_item.html.haml
@@ -7,7 +7,7 @@
           - @tray.errors.full_messages.each do |msg|
             %li= msg
     .field
-      = label_tag :items_in_tray
+      = label_tag :tray_count, "Items in Tray"
       = text_field_tag :tray_count, @tray_count,
         required: true, autofocus: true, placeholder: 'Enter a number of items'
     .actions

--- a/app/views/trays/count_item.html.haml
+++ b/app/views/trays/count_item.html.haml
@@ -7,9 +7,8 @@
           - @tray.errors.full_messages.each do |msg|
             %li= msg
     .field
-      = f.label :tray_count, "Items in Tray"
-      = f.text_field :tray_count, @tray_count,
+      = label_tag :tray_count, "Items in Tray"
+      = text_field_tag :tray_count, nil,
         required: true, autofocus: true, placeholder: 'Enter a number of items'
     .actions
-      = f.submit 'Validate', class: 'btn btn-primary'
-%br
+      = submit_tag 'Validate', class: 'btn btn-primary'

--- a/app/views/trays/count_item.html.haml
+++ b/app/views/trays/count_item.html.haml
@@ -7,9 +7,9 @@
           - @tray.errors.full_messages.each do |msg|
             %li= msg
     .field
-      = label_tag :tray_count, "Items in Tray"
-      = text_field_tag :tray_count, @tray_count,
+      = f.label :tray_count, "Items in Tray"
+      = f.text_field :tray_count, @tray_count,
         required: true, autofocus: true, placeholder: 'Enter a number of items'
     .actions
-      = submit_tag 'Validate', class: 'btn btn-primary'
+      = f.submit 'Validate', class: 'btn btn-primary'
 %br

--- a/app/views/trays/count_item.html.haml
+++ b/app/views/trays/count_item.html.haml
@@ -11,4 +11,4 @@
       = text_field_tag :tray_count, nil,
         required: true, autofocus: true, placeholder: 'Enter a number of items'
     .actions
-      = submit_tag 'Validate', class: 'btn btn-primary'
+      = submit_tag 'Enter', class: 'btn btn-primary'

--- a/app/views/trays/count_item.html.haml
+++ b/app/views/trays/count_item.html.haml
@@ -1,0 +1,15 @@
+.scan
+  = form_tag count_tray_item_path(@tray) do |f|
+    - if @tray.errors.any?
+      #error_explanation
+        %h2= "#{pluralize(@tray.errors.count, "error")} prohibited this tray from being saved:"
+        %ul
+          - @tray.errors.full_messages.each do |msg|
+            %li= msg
+    .field
+      = label_tag :items_in_tray
+      = text_field_tag :tray_count, @tray_count,
+        required: true, autofocus: true, placeholder: 'Enter a number of items'
+    .actions
+      = submit_tag 'Validate', class: 'btn btn-primary'
+%br

--- a/app/views/trays/show_item.html.haml
+++ b/app/views/trays/show_item.html.haml
@@ -23,7 +23,8 @@
     .actions
       = submit_tag 'Save', class: 'btn btn-primary'
 %br
-= button_to "Done", count_tray_item_path, method: :get, class: 'btn pull-right btn-primary'
+= button_to "Done", count_tray_item_path, method: :get,
+  class: 'btn pull-right btn-primary'
 %table.table.table-striped.condensed{"data-toggle" => "table"}
   %thead
     %tr

--- a/app/views/trays/show_item.html.haml
+++ b/app/views/trays/show_item.html.haml
@@ -23,7 +23,7 @@
     .actions
       = submit_tag 'Save', class: 'btn btn-primary'
 %br
-= button_to "Done", trays_items_path, method: :get, class: 'btn pull-right btn-primary'
+= button_to "Done", count_tray_item_path, method: :get, class: 'btn pull-right btn-primary'
 %table.table.table-striped.condensed{"data-toggle" => "table"}
   %thead
     %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
   errors:
     barcode_not_found: "Barcode %{barcode} not found. Put item with barcode %{barcode} on problem shelf."
     barcode_not_valid: "Barcode \"%{barcode}\" is not valid, please re-scan."
+  trays:
+    items_count_not_match: "Manual and System Tray counts don't match! Try again."
   batches:
     status:
       active: "You already have an active batch in process"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
     barcode_not_found: "Barcode %{barcode} not found. Put item with barcode %{barcode} on problem shelf."
     barcode_not_valid: "Barcode \"%{barcode}\" is not valid, please re-scan."
   trays:
-    items_count_not_match: "Manual and System Tray counts don't match! Try again."
+    items_count_not_match: "The count you entered and the computer's count did not match.  Recount and enter again."
   batches:
     status:
       active: "You already have an active batch in process"
@@ -58,6 +58,7 @@ en:
     items_show: " "
     items_issues: "Items with Issues"
     trays_items: "Items to Tray"
+    trays_count_item: "Tray's Item Count"
     trays_show_item: "Add Item"
     trays_show: "Tray Location"
     trays_index: "Tray to Shelf"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
   get "trays/items/:id/missing", to: "trays#missing", as: "missing_tray_item"
   get "trays/items/:id/invalid", to: "trays#invalid", as: "invalid_tray_item"
   post "trays/items/:id/create", to: "trays#create_item", as: "create_tray_item"
+  get "trays/items/:id/count_item", to: "trays#count_item", as: "count_tray_item"
+  post "trays/items/:id/count_item", to: "trays#count_item", as: "validate_count_tray"
 
   post "trays/:id/withdraw", to: "trays#withdraw", as: "withdraw_tray"
 

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -543,7 +543,7 @@ feature "Trays", type: :feature do
       expect(current_path).to eq(show_tray_item_path(id: tray.id))
       expect(page).to have_content item.barcode
       click_button "Done"
-      expect(current_path).to eq(trays_items_path)
+      expect(current_path).to eq(count_tray_item_path(id: tray.id))
     end
 
     it "allows the user to finish with the current tray when processing items via scan" do

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -549,12 +549,12 @@ feature "Trays", type: :feature do
     it "allows the user to validate same Manual and System counts of items in the tray" do
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
-        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" } ).
         to_return{ { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
-        with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
-          headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
-        to_return{ |response| { status: 200, body: {results: {status: "OK", message: "Item stocked"}}.to_json, headers: {} } }
+        with(body: { "barcode" => "#{item.barcode}", "item_id" => "#{item.id}", "tray_code" => "#{tray.barcode}" },
+          headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.9.1' }).
+        to_return{ |response| { status: 200, body: { results: { status: "OK", message: "Item stocked" } }.to_json, headers: {} } }
       visit trays_items_path
       fill_in "Tray", with: tray.barcode
       click_button "Save"

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -567,7 +567,7 @@ feature "Trays", type: :feature do
       click_button "Done"
       expect(current_path).to eq(count_tray_item_path(id: tray.id))
       fill_in "Items in Tray", with: 1
-      click_button "Validate"
+      click_button "Enter"
       expect(current_path).to eq(trays_items_path)
     end
 
@@ -579,7 +579,7 @@ feature "Trays", type: :feature do
       click_button "Done"
       expect(current_path).to eq(count_tray_item_path(id: tray.id))
       fill_in "Items in Tray", with: 1
-      click_button "Validate"
+      click_button "Enter"
       expect(current_path).to eq(count_tray_item_path(id: tray.id))
       expect(page).to have_content I18n.t("trays.items_count_not_match")
     end

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -549,7 +549,7 @@ feature "Trays", type: :feature do
     it "allows the user to validate same Manual and System counts of items in the tray" do
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
-        with(headers: { "User-Agent" => "Faraday v0.9.1" } ).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
         to_return{ { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: { "barcode" => "#{item.barcode}", "item_id" => "#{item.id}", "tray_code" => "#{tray.barcode}" },

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -546,6 +546,44 @@ feature "Trays", type: :feature do
       expect(current_path).to eq(count_tray_item_path(id: tray.id))
     end
 
+    it "allows the user to validate same Manual and System counts of items in the tray" do
+      item_uri = api_item_url(item)
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return{ { status: 200, body: response_body, headers: {} } }
+      stub_request(:post, api_stock_url).
+        with(body: {"barcode"=>"#{item.barcode}", "item_id"=>"#{item.id}", "tray_code"=>"#{tray.barcode}"},
+          headers: {'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.1'}).
+        to_return{ |response| { status: 200, body: {results: {status: "OK", message: "Item stocked"}}.to_json, headers: {} } }
+      visit trays_items_path
+      fill_in "Tray", with: tray.barcode
+      click_button "Save"
+      expect(current_path).to eq(show_tray_item_path(id: tray.id))
+      fill_in "Item", with: item.barcode
+      fill_in "Thickness", with: Faker::Number.number(1)
+      click_button "Save"
+      expect(current_path).to eq(show_tray_item_path(id: tray.id))
+      expect(page).to have_content item.barcode
+      click_button "Done"
+      expect(current_path).to eq(count_tray_item_path(id: tray.id))
+      fill_in "Items in Tray", with: 1
+      click_button "Validate"
+      expect(current_path).to eq(trays_items_path)
+    end
+
+    it "allows the user to validate different Manual and System counts of items in the tray" do
+      visit trays_items_path
+      fill_in "Tray", with: tray.barcode
+      click_button "Save"
+      expect(current_path).to eq(show_tray_item_path(id: tray.id))
+      click_button "Done"
+      expect(current_path).to eq(count_tray_item_path(id: tray.id))
+      fill_in "Items in Tray", with: 1
+      click_button "Validate"
+      expect(current_path).to eq(count_tray_item_path(id: tray.id))
+      expect(page).to have_content I18n.t("trays.items_count_not_match")
+    end
+
     it "allows the user to finish with the current tray when processing items via scan" do
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -550,7 +550,7 @@ feature "Trays", type: :feature do
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
         with(headers: { "User-Agent" => "Faraday v0.9.1" }).
-        to_return{ { status: 200, body: response_body, headers: {} } }
+        to_return { { status: 200, body: response_body, headers: {} } }
       stub_request(:post, api_stock_url).
         with(body: { "barcode" => "#{item.barcode}", "item_id" => "#{item.id}", "tray_code" => "#{tray.barcode}" },
           headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.9.1' }).


### PR DESCRIPTION
When a tray is full the user clicks "Done".  At that point the user is prompted to "Enter the number of items in the tray."
If the count matches, the user is taken to the Stocking page to scan the next Tray.
If the count does NOT match, the user receives an error message and is prompted to recount, and enter the count again.