### PR TITLE
Bugfix: The IMS will sometimes assign an item from a batch to a bin, without the user scanning its barcode in the UI

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -120,14 +120,18 @@ class BatchesController < ApplicationController
 
   def scan_bin
     @batch = current_user.batches.where(active: true).first
-
     if @batch.blank?
       flash[:error] = "#{current_user.username} does not have an active batch, please create one."
       redirect_to batches_path
       return
     end
 
-    @match = @batch.current_match
+    @match = Match.find(params[:match_id])
+    if @match.blank?
+      flash[:error] = "Match #{params[:match_id]} is not a part of this batch."
+      redirect_to bin_batch_path
+      return
+    end
 
     if params[:commit] == "Skip"
       @match.processed = "skipped"

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -80,7 +80,7 @@ class BatchesController < ApplicationController
       return
     end
 
-    @match = @batch.current_match
+    @match = Match.find(params[:match_id])
 
     if params[:commit] == "Skip"
       @match.processed = "skipped"
@@ -127,11 +127,6 @@ class BatchesController < ApplicationController
     end
 
     @match = Match.find(params[:match_id])
-    if @match.blank?
-      flash[:error] = "Match #{params[:match_id]} is not a part of this batch."
-      redirect_to bin_batch_path
-      return
-    end
 
     if params[:commit] == "Skip"
       @match.processed = "skipped"

--- a/app/views/batches/bin.html.haml
+++ b/app/views/batches/bin.html.haml
@@ -3,6 +3,7 @@
     .field
       = label_tag :barcode, "Bin"
       = text_field_tag :barcode, nil, autofocus: "autofocus"
+      = hidden_field_tag :match_id, @match.id
     .actions
       = submit_tag 'Save', class: 'btn pull-left btn-primary'
       = submit_tag 'Skip', class: 'btn pull-right btn-warning'

--- a/app/views/batches/retrieve.html.haml
+++ b/app/views/batches/retrieve.html.haml
@@ -3,6 +3,7 @@
     .field
       = label_tag :barcode, "Item"
       = text_field_tag :barcode, nil, autofocus: "autofocus"
+      = hidden_field_tag :match_id, @match.id
   .form-group
     .actions
       = submit_tag 'Save', class: 'btn pull-left btn-primary'

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -3,10 +3,12 @@ require "rails_helper"
 RSpec.describe BatchesController, type: :controller do
   let(:user) { FactoryGirl.create(:user, admin: true) }
   let(:batch) { FactoryGirl.create(:batch, user: user) }
-  let(:match) { FactoryGirl.create(:match, batch: batch) }
+  let(:item) { FactoryGirl.create(:item) }
+  let(:match) { FactoryGirl.create(:match, batch: batch, item: item) }
 
   before(:each) do
     sign_in(user)
+    match
   end
 
   describe "GET item" do
@@ -35,11 +37,25 @@ RSpec.describe BatchesController, type: :controller do
   end
 
   describe "GET scan_bin" do
-    subject { get :scan_bin, commit: "Skip" }
+    subject { get :scan_bin, match_id: match.id }
+
+    context "when there is no batch for the user" do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'flashes an error message' do
+        subject
+        expect(flash[:error]).to eq("#{user.username} does not have an active batch, please create one.")
+      end
+
+      it 'redirects to bin batch' do
+        expect(subject).to redirect_to(batches_path)
+      end
+    end
 
     context "skipping scan_bin" do
+      subject { get :scan_bin, commit: "Skip", match_id: match.id }
+
       it "logs a SkippedItem activity on Skip" do
-        allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
         expect(ActivityLogger).to receive(:skip_item)
         subject
       end

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe BatchesController, type: :controller do
   end
 
   describe "GET item" do
+    subject { get :item, match_id: match.id }
+
     context "skipping an item" do
-      subject { get :item, commit: "Skip" }
+      subject { get :item, commit: "Skip", match_id: match.id }
       it "logs a SkippedItem activity on Skip" do
         allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
         expect(ActivityLogger).to receive(:skip_item)
@@ -22,7 +24,7 @@ RSpec.describe BatchesController, type: :controller do
     end
 
     context "saving an item" do
-      subject { get :item, commit: "Save", barcode: match.item.barcode }
+      subject { get :item, commit: "Save", barcode: match.item.barcode, match_id: match.id }
       it "logs an AcceptedItem activity on Save" do
         allow_any_instance_of(Batch).to receive(:current_match).and_return(match)
         expect(ActivityLogger).to receive(:accept_item)
@@ -32,7 +34,7 @@ RSpec.describe BatchesController, type: :controller do
 
     it "requires admin permissions" do
       expect_any_instance_of(described_class).to receive(:require_admin)
-      get :item
+      subject
     end
   end
 

--- a/spec/controllers/batches_controller_spec.rb
+++ b/spec/controllers/batches_controller_spec.rb
@@ -11,6 +11,169 @@ RSpec.describe BatchesController, type: :controller do
     match
   end
 
+  describe "GET index" do
+    subject { get :index }
+
+    context 'when the user has a batch' do
+      let(:batch) { FactoryGirl.create(:batch, user: user) }
+
+      it 'redirects to current batch' do
+        expect(subject).to redirect_to(current_batch_path)
+      end
+
+      it 'assigns data for the view' do
+        subject
+        expect(assigns(:data)).to eq([])
+      end
+    end
+
+    context 'when the user has no batch' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'renders index view' do
+        subject
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+
+  describe "POST create" do
+    subject { post :create, "commit"=>"Save", "batch"=>["69-156", "70-196"] }
+
+    context 'when the user has a batch' do
+      let(:batch) { FactoryGirl.create(:batch, user: user) }
+
+      it 'redirects to current batch' do
+        expect(subject).to redirect_to(current_batch_path)
+      end
+    end
+
+    context 'when the user has no batch' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'uses BuildBatch to create the batch' do
+        expect(BuildBatch).to receive(:call).with(["69-156", "70-196"], user)
+        subject
+      end
+
+      it 'redirects to root' do
+        allow(BuildBatch).to receive(:call).and_return(nil)
+        expect(subject).to redirect_to(root_path)
+      end
+    end
+
+    context 'when batch is empty' do
+      subject { post :create, "commit"=>"Save" }
+
+      it 'redirects to batches' do
+        expect(subject).to redirect_to(batches_path)
+      end
+    end
+  end
+
+  describe "GET current" do
+    subject { get :current }
+
+    context 'when the user has a batch' do
+      let(:batch) { FactoryGirl.create(:batch, user: user) }
+
+      it 'renders current view' do
+        subject
+        expect(response).to render_template(:current)
+      end
+
+      it 'assigns batch for the view' do
+        subject
+        expect(assigns(:batch)).to eq(batch)
+      end
+    end
+
+    context 'when the user has no batch' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'redirects to batches' do
+        expect(subject).to redirect_to(batches_path)
+      end
+    end
+  end
+
+  describe "POST remove" do
+    context 'when match id is given' do
+      subject { post :remove, match_id: match.id, commit: "Remove" }
+
+      it 'calls DestroyMatch' do
+        expect(DestroyMatch).to receive(:call).with(match: match, user: user)
+        subject
+      end
+
+      it 'calls DissociateItemFromBin' do
+        expect(DissociateItemFromBin).to receive(:call).with(item: item, user: user)
+        subject
+      end
+
+      it 'calls FinishBatch' do
+        expect(FinishBatch).to receive(:call).with(batch, user)
+        subject
+      end
+
+      it 'redirects to current batch' do
+        expect(subject).to redirect_to(current_batch_path)
+      end
+    end
+
+    context 'when match id is not given' do
+      subject { post :remove, commit: "Remove" }
+
+      it 'does not call DestroyMatch' do
+        expect(DestroyMatch).not_to receive(:call)
+        subject
+      end
+
+      it 'does not call DissociateItemFromBin' do
+        expect(DissociateItemFromBin).not_to receive(:call)
+        subject
+      end
+
+      it 'does not call FinishBatch' do
+        expect(FinishBatch).not_to receive(:call)
+        subject
+      end
+
+      it 'redirects to current batch' do
+        expect(subject).to redirect_to(current_batch_path)
+      end
+    end
+  end
+
+  describe "GET retrieve" do
+    subject { get :retrieve }
+
+    context 'when the user has no batch' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'redirects to batches' do
+        expect(subject).to redirect_to(batches_path)
+      end
+    end
+
+    context 'when the user has a batch' do
+      let(:batch) { FactoryGirl.create(:batch, user: user) }
+
+      it 'assigns the match for the view' do
+        subject
+        expect(assigns(:match)).to eq(match)
+      end
+
+      context 'but there are no remaining unprocessed matches' do
+        let(:match) { FactoryGirl.create(:match, item: item, batch: batch, processed: "accepted") }
+
+        it 'redirects to finalize batch' do
+          expect(subject).to redirect_to(finalize_batch_path)
+        end
+      end
+    end
+  end
+
   describe "GET item" do
     subject { get :item, match_id: match.id }
 
@@ -35,6 +198,37 @@ RSpec.describe BatchesController, type: :controller do
     it "requires admin permissions" do
       expect_any_instance_of(described_class).to receive(:require_admin)
       subject
+    end
+  end
+
+  describe "GET bin" do
+    subject { get :bin }
+
+    context 'when the user has no batch' do
+      let(:batch) { FactoryGirl.create(:batch) }
+
+      it 'redirects to batches' do
+        expect(subject).to redirect_to(batches_path)
+      end
+    end
+
+    context 'when the user has a batch' do
+      let(:batch) { FactoryGirl.create(:batch, user: user) }
+
+      it 'renders bin view' do
+        subject
+        expect(response).to render_template(:bin)
+      end
+
+      it 'assigns batch for the view' do
+        subject
+        expect(assigns(:batch)).to eq(batch)
+      end
+
+      it 'assigns match for the view' do
+        subject
+        expect(assigns(:match)).to eq(match)
+      end
     end
   end
 


### PR DESCRIPTION
Problem was due to the usage of Batch.current_match. It made an assumption about which match should be modified when posting back data. If the user clicked on it multiple times, such as in the case of an impatient user clicking the button again before receiving a response, it would receive all of the requests and cause each match in order to be accepted, without the user being aware. Changed it to expect the form to post the match id as a param so that it's explicitly modifying the correct match. 

This also affected the form that requires the user to accept an item by scanning it. It was possible to skip multiple items without realizing it. Fixed this as well.