### PR TITLE
As a user on Item Search I can search for a Bib number with or without entering the leading zeros

### DIFF
--- a/app/services/search_items.rb
+++ b/app/services/search_items.rb
@@ -55,7 +55,8 @@ class SearchItems
       paginate page: page, per_page: per_page
 
       if search_fulltext?
-        fulltext(fetch(:criteria), fields: fulltext_fields)
+        criteria = exact_match? ? fetch(:criteria) : "*#{fetch(:criteria)}*"
+        fulltext(criteria, fields: fulltext_fields)
       end
 
       if search_conditions?
@@ -123,6 +124,10 @@ class SearchItems
 
   def search_conditions?
     has_filter?(:conditions) && has_filter?(:condition_bool)
+  end
+
+  def exact_match?
+    false || (has_filter?(:exact_match) && fetch(:exact_match))
   end
 
   def search_date?

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -3,7 +3,8 @@
     %a.list-group-item.list-group-item-success Criteria
     #criteria.input-group
       %div
-        = select_tag :criteria_type, options_for_select(SearchItems::CRITERIA_TYPES, @params[:criteria_type])
+        = select_tag :criteria_type,
+                     options_for_select(SearchItems::CRITERIA_TYPES, @params[:criteria_type])
         = text_field_tag :criteria, @params[:criteria], autofocus: "autofocus"
 
     %a.list-group-item.list-group-item-success{"data-toggle" => "collapse", :href => "#date-range"}

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -4,7 +4,8 @@
     #criteria.input-group
       %div
         = select_tag :criteria_type,
-                     options_for_select(SearchItems::CRITERIA_TYPES, @params[:criteria_type])
+                     options_for_select(SearchItems::CRITERIA_TYPES,
+                                        @params[:criteria_type])
         = text_field_tag :criteria, @params[:criteria], autofocus: "autofocus"
 
     %a.list-group-item.list-group-item-success{"data-toggle" => "collapse", :href => "#date-range"}

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -7,6 +7,9 @@
                      options_for_select(SearchItems::CRITERIA_TYPES,
                                         @params[:criteria_type])
         = text_field_tag :criteria, @params[:criteria], autofocus: "autofocus"
+      %div
+        = label_tag "Exact match?"
+        = check_box_tag :exact_match, 1, @params[:exact_match]
 
     %a.list-group-item.list-group-item-success{"data-toggle" => "collapse", :href => "#date-range"}
       %span.glyphicon.glyphicon-plus

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -2,9 +2,9 @@
   .list-group.panel.search
     %a.list-group-item.list-group-item-success Criteria
     #criteria.input-group
-      = select_tag :criteria_type, options_for_select(SearchItems::CRITERIA_TYPES, @params[:criteria_type])
-      = text_field_tag :criteria, @params[:criteria], autofocus: "autofocus"
-      = label_tag :criteria, 'Use * for wildcard matches.'
+      %div
+        = select_tag :criteria_type, options_for_select(SearchItems::CRITERIA_TYPES, @params[:criteria_type])
+        = text_field_tag :criteria, @params[:criteria], autofocus: "autofocus"
 
     %a.list-group-item.list-group-item-success{"data-toggle" => "collapse", :href => "#date-range"}
       %span.glyphicon.glyphicon-plus
@@ -67,4 +67,3 @@
           %td= item.conditions.present? ? item.conditions.join(", ") : ''
 - if !@results.blank?
   = paginate @results
-

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -135,6 +135,7 @@ feature "Search", :type => :feature, :search => true do
       visit search_path
       select("Title", :from => "criteria_type")
       fill_in "criteria", :with => item.title
+      find(:css, "#exact_match").set(true)
       click_button "Search"
       expect(current_path).to eq(search_path)
       expect(page).to have_content item.title
@@ -157,6 +158,7 @@ feature "Search", :type => :feature, :search => true do
       visit search_path
       select("Tray", :from => "criteria_type")
       fill_in "criteria", :with => tray.barcode
+      find(:css, "#exact_match").set(true)
       click_button "Search"
       expect(current_path).to eq(search_path)
       expect(page).to have_content item.title
@@ -168,6 +170,7 @@ feature "Search", :type => :feature, :search => true do
       visit search_path
       select("Shelf", :from => "criteria_type")
       fill_in "criteria", :with => shelf.barcode
+      find(:css, "#exact_match").set(true)
       click_button "Search"
       expect(current_path).to eq(search_path)
       expect(page).to have_content item.title
@@ -193,6 +196,7 @@ feature "Search", :type => :feature, :search => true do
       find(:css, "#condition_bool_all").set(true)
       find(:css, "#conditions_#{item.conditions[0]}").set(true)
       find(:css, "#conditions_#{item.conditions[1]}").set(true)
+      find(:css, "#exact_match").set(true)
       click_button "Search"
       expect(current_path).to eq(search_path)
       expect(page).to have_content item.title
@@ -213,6 +217,7 @@ feature "Search", :type => :feature, :search => true do
       fill_in "criteria", :with => "TRAY"
       find(:css, "#condition_bool_none").set(true)
       find(:css, "#conditions_PAGES-DET").set(true)
+      find(:css, "#exact_match").set(true)
       click_button "Search"
       expect(current_path).to eq(search_path)
       expect(page).to have_content item.title
@@ -279,6 +284,7 @@ feature "Search", :type => :feature, :search => true do
       visit search_path
       select("Tray", :from => "criteria_type")
       fill_in "criteria", :with => tray.barcode
+      find(:css, "#exact_match").set(true)
       click_button "Export"
       csv = CSV.parse(page.text)
       expect(csv.first).to eq [item.barcode, item.bib_number, item.isbn_issn, item.title, item.author, item.chron, item.tray.present? ? item.tray.barcode : '', item.shelf.present? ? item.shelf.barcode : '', item.conditions.join(", ")]

--- a/spec/services/search_items_spec.rb
+++ b/spec/services/search_items_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SearchItems do
   end
 
   let(:item) { FactoryGirl.create(:item, chron: "TEST CHRON") }
-  let(:filter) { {} }
+  let(:filter) { { exact_match: true } }
   subject { described_class.call(filter) }
   let(:results) { subject.results }
 
@@ -33,7 +33,7 @@ RSpec.describe SearchItems do
   end
 
   context "page" do
-    let(:filter) { { criteria_type: "any", criteria: item.title, page: 2 } }
+    let(:filter) { { criteria_type: "any", criteria: item.title, page: 2, exact_match: true } }
 
     it "returns the second page of results" do
       expect(subject.total).to eq(1)
@@ -43,7 +43,7 @@ RSpec.describe SearchItems do
 
   context "per_page" do
     let(:item) { FactoryGirl.create(:item, chron: "1") }
-    let(:filter) { { criteria_type: "any", criteria: item.title } }
+    let(:filter) { { criteria_type: "any", criteria: item.title, exact_match: true } }
 
     it "defaults to 50 per page" do
       50.times do
@@ -70,7 +70,7 @@ RSpec.describe SearchItems do
 
   describe "criteria_type" do
     describe "any" do
-      let(:filter) { { criteria_type: "any" } }
+      let(:filter) { { criteria_type: "any", exact_match: true } }
 
       [
         :barcode,
@@ -120,7 +120,7 @@ RSpec.describe SearchItems do
       :author,
     ].each do |criteria_type_field|
       describe "#{criteria_type_field}" do
-        let(:filter) { { criteria_type: criteria_type_field.to_s } }
+        let(:filter) { { criteria_type: criteria_type_field.to_s, exact_match: true } }
         it "can find an item by #{criteria_type_field}" do
           allow(item).to receive(criteria_type_field).and_return("#{criteria_type_field} value")
           Sunspot.index(item)
@@ -137,7 +137,7 @@ RSpec.describe SearchItems do
     end
 
     describe "tray" do
-      let(:filter) { { criteria_type: "tray" } }
+      let(:filter) { { criteria_type: "tray", exact_match: true } }
 
       it "searches the tray barcode" do
         item.tray = FactoryGirl.create(:tray)
@@ -154,7 +154,7 @@ RSpec.describe SearchItems do
     end
 
     describe "shelf" do
-      let(:filter) { { criteria_type: "shelf" } }
+      let(:filter) { { criteria_type: "shelf", exact_match: true } }
 
       it "searches the shelf barcode" do
         item.shelf = FactoryGirl.create(:shelf)
@@ -171,7 +171,7 @@ RSpec.describe SearchItems do
     end
 
     describe "ERROR" do
-      let(:filter) { { criteria_type: "ERROR", criteria: "ERROR" } }
+      let(:filter) { { criteria_type: "ERROR", criteria: "ERROR", exact_match: true } }
 
       it "returns an empty result set" do
         filter[:criteria] = "ERROR"
@@ -186,7 +186,7 @@ RSpec.describe SearchItems do
     let(:item) { FactoryGirl.create(:item, conditions: conditions) }
 
     context "all" do
-      let(:filter) { { condition_bool: "all" } }
+      let(:filter) { { condition_bool: "all", exact_match: true } }
 
       it "matches all conditions" do
         filter[:conditions] = {}.tap do |hash|
@@ -211,7 +211,7 @@ RSpec.describe SearchItems do
     end
 
     context "any" do
-      let(:filter) { { condition_bool: "any" } }
+      let(:filter) { { condition_bool: "any", exact_match: true } }
 
       it "matches all conditions" do
         filter[:conditions] = {}.tap do |hash|
@@ -243,7 +243,7 @@ RSpec.describe SearchItems do
     end
 
     context "any" do
-      let(:filter) { { condition_bool: "none" } }
+      let(:filter) { { condition_bool: "none", exact_match: true } }
 
       it "does not match all conditions" do
         filter[:conditions] = {}.tap do |hash|


### PR DESCRIPTION
The search will now, by default, wrap the query in * to find anything that contains the criteria given. The ticket was written from the perspective of searching bib numbers, but I can't imagine we wouldn't expect this behavior on all fields. If we do need to ever query for exact matches, we can pass an exact_match=true param and it will not wrap the query in *. At the moment, I don't have this as an input anywhere on the form because I wasn't sure if this would really be needed. Trying to keep the form simple, but if we find we need it, it will be simple to add a checkbox to do an exact match.