### PR TITLE
As an Admin user I do not have to do Tray QC

### DIFF
--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -227,6 +227,11 @@ class TraysController < ApplicationController
   end
 
   def count_items
+    if user_admin?
+      redirect_to trays_items_path
+      return
+    end
+
     @tray = Tray.find(params[:id])
     @validation_count_items = params[:validation_count_items]
     tray_count = params[:tray_count]

--- a/spec/features/batch_retrieval_spec.rb
+++ b/spec/features/batch_retrieval_spec.rb
@@ -13,7 +13,7 @@ feature "Retrieve", :type => :feature do
     let(:match) { FactoryGirl.create(:match, batch: batch, request: request, item: item) }
 
     before(:each) do
-      login_user
+      login_admin
       @match = match
     end
 

--- a/spec/features/batches_spec.rb
+++ b/spec/features/batches_spec.rb
@@ -57,7 +57,7 @@ feature "Build", :type => :feature, :search => true do
 
     before(:each) do
       save_all
-      login_user
+      login_admin
     end
 
     after(:all) do

--- a/spec/features/bins_spec.rb
+++ b/spec/features/bins_spec.rb
@@ -12,7 +12,7 @@ feature "Bins", :type => :feature do
 
 
     before(:each) do
-      login_user
+      login_admin
 
       @bin = bin
       @match = match

--- a/spec/features/item_to_shelf_spec.rb
+++ b/spec/features/item_to_shelf_spec.rb
@@ -14,7 +14,7 @@ feature "Shelves", :type => :feature do
       @tray2 = FactoryGirl.create(:tray, barcode: "TRAY-AH11", shelf: @shelf2)
       @item3 = FactoryGirl.create(:item, barcode: "1234567", tray: @tray2)
 
-      login_user
+      login_admin
 
       item_uri = api_item_url(@item)
       response_body = {

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -5,7 +5,7 @@ feature "Items", type: :feature do
 
   describe "when signed in" do
     before(:each) do
-      login_user
+      login_admin
 
       @tray = FactoryGirl.create(:tray)
       @shelf = FactoryGirl.create(:shelf)

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -55,7 +55,7 @@ feature "Search", :type => :feature, :search => true do
 
     before(:each) do
       save_all
-      login_user
+      login_admin
     end
 
     after(:all) do

--- a/spec/features/shelves_spec.rb
+++ b/spec/features/shelves_spec.rb
@@ -9,7 +9,7 @@ feature "Shelves", type: :feature do
     let!(:user) { FactoryGirl.create(:user) }
 
     before(:each) do
-      login_user
+      login_admin
     end
 
     context "shelf details" do

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -11,7 +11,7 @@ feature "Trays", type: :feature do
 
   describe "when signed in" do
     before(:each) do
-      login_user
+      login_admin
 
       stub_request(:get, api_item_url(item)).
         with(headers: { "User-Agent" => "Faraday v0.9.1" }).
@@ -525,7 +525,7 @@ feature "Trays", type: :feature do
     end
 
     it "skips the tray counts when the user is an admin" do
-      login_user
+      login_admin
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
         with(headers: { "User-Agent" => "Faraday v0.9.1" }).

--- a/spec/features/trays_spec.rb
+++ b/spec/features/trays_spec.rb
@@ -524,7 +524,31 @@ feature "Trays", type: :feature do
       expect(page).to have_no_content item.barcode
     end
 
+    it "skips the tray counts when the user is an admin" do
+      login_user
+      item_uri = api_item_url(item)
+      stub_request(:get, item_uri).
+        with(headers: { "User-Agent" => "Faraday v0.9.1" }).
+        to_return { { status: 200, body: response_body, headers: {} } }
+      stub_request(:post, api_stock_url).
+        with(body: { "barcode" => "#{item.barcode}", "item_id" => "#{item.id}", "tray_code" => "#{tray.barcode}" },
+          headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'User-Agent' => 'Faraday v0.9.1' }).
+        to_return{ |response| { status: 200, body: { results: { status: "OK", message: "Item stocked" } }.to_json, headers: {} } }
+      visit trays_items_path
+      fill_in "Tray", with: tray.barcode
+      click_button "Save"
+      expect(current_path).to eq(show_tray_item_path(id: tray.id))
+      fill_in "Item", with: item.barcode
+      fill_in "Thickness", with: Faker::Number.number(1)
+      click_button "Save"
+      expect(current_path).to eq(show_tray_item_path(id: tray.id))
+      expect(page).to have_content item.barcode
+      click_button "Done"
+      expect(current_path).to eq(trays_items_path)
+    end
+
     it "allows the user to finish with the current tray when processing items" do
+      login_worker
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
         with(headers: { "User-Agent" => "Faraday v0.9.1" }).
@@ -546,7 +570,8 @@ feature "Trays", type: :feature do
       expect(current_path).to eq(count_tray_item_path(id: tray.id))
     end
 
-    it "allows the user to validate same Manual and System counts of items in the tray" do
+    it "allows a worker user to validate same Manual and System counts of items in the tray" do
+      login_worker
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
         with(headers: { "User-Agent" => "Faraday v0.9.1" }).
@@ -571,7 +596,8 @@ feature "Trays", type: :feature do
       expect(current_path).to eq(trays_items_path)
     end
 
-    it "allows the user to validate different Manual and System counts of items in the tray" do
+    it "allows a worker user to validate different Manual and System counts of items in the tray" do
+      login_worker
       visit trays_items_path
       fill_in "Tray", with: tray.barcode
       click_button "Save"
@@ -584,7 +610,8 @@ feature "Trays", type: :feature do
       expect(page).to have_content I18n.t("trays.count_items_not_match")
     end
 
-    it "allows the user to validate two times Manual and System counts of items in the tray" do
+    it "allows a worker user to validate two times Manual and System counts of items in the tray" do
+      login_worker
       item_uri = api_item_url(item)
       stub_request(:get, item_uri).
         with(headers: { "User-Agent" => "Faraday v0.9.1" }).
@@ -639,6 +666,7 @@ feature "Trays", type: :feature do
     end
 
     it "warns when a try is probably full" do
+      login_worker
       items = []
       14.times do
         item = FactoryGirl.create(:item, barcode: rand.to_s[2..15])

--- a/spec/features/view_active_batches_spec.rb
+++ b/spec/features/view_active_batches_spec.rb
@@ -12,7 +12,7 @@ feature "View Active", type: :feature do
     let(:match) { FactoryGirl.create(:match, batch: batch, request: request, item: item) }
 
     before(:each) do
-      login_user
+      login_admin
       @match = match
     end
 

--- a/spec/features/view_processed_batches_spec.rb
+++ b/spec/features/view_processed_batches_spec.rb
@@ -12,7 +12,7 @@ feature "View Processed", type: :feature do
     let(:match) { FactoryGirl.create(:match, batch: batch, request: request, item: item) }
 
     before(:each) do
-      login_user
+      login_admin
       @match = match
     end
 

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -7,7 +7,7 @@ module AuthenticationHelper
     end
   end
 
-  def login_user
+  def login_admin
     @user = FactoryGirl.create(:user, admin: true)
     login_as @user, scope: :user
     @user

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -13,6 +13,12 @@ module AuthenticationHelper
     @user
   end
 
+  def login_worker
+    @user = FactoryGirl.create(:user, admin: false, worker: true)
+    login_as @user, scope: :user
+    @user
+  end
+
 =begin - placeholder, because we will need this and I will forget otherwise
   def login_admin
     @user = XXX Do something special for admins


### PR DESCRIPTION
Admin users should not have to count the items as an additional QC step when stocking an item to a tray. 

Changed the count_items to redirect to the trays/items path when the user is an admin