### PR TITLE
As a user I can QC the items in a Tray

### DIFF
--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -156,6 +156,7 @@ a.list-group-item[aria-expanded="true"] {
 #stocking,
 #items,
 #batches,
+#qc,
 #reports,
 #settings {
   .list-group-item {
@@ -266,9 +267,13 @@ hr {
   > tbody {
     tr:nth-of-type(odd),
     tr:nth-of-type(even) {
+      &.check-items-fail,
       &.item-metadata-not-found,
       &.item-metadata-not-for-annex {
         background-color: $alert-danger-bg;
+      }
+      &.check-items-success {
+        background-color: $alert-success-bg;
       }
     }
   }

--- a/app/controllers/trays_controller.rb
+++ b/app/controllers/trays_controller.rb
@@ -238,19 +238,19 @@ class TraysController < ApplicationController
   def validate_items
     @tray = Tray.find(params[:id])
     item_barcode = params[:barcode]
-    @item = Item.where(barcode: item_barcode).take
+    item = Item.where(barcode: item_barcode).take
     @scanned = params[:scanned].present? ? params[:scanned] : []
 
-    if @item.nil?
+    if item.nil?
       if IsValidItem.call(item_barcode)
         flash[:error] = I18n.t("errors.barcode_not_found", barcode: item_barcode)
-        new_item = Item.create!(barcode: item_barcode, thickness: 0)
-        ActivityLogger.create_item(item: new_item, user: current_user)
-        AddIssue.call(item: new_item,
+        item = Item.create!(barcode: item_barcode, thickness: 0)
+        ActivityLogger.create_item(item: item, user: current_user)
+        AddIssue.call(item: item,
                       user: current_user,
                       type: "tray_mismatch",
                       message: "Item failed QC. Was physically in tray '#{@tray.barcode}', but the item did not exist.")
-        SyncItemMetadata.call(item: new_item, user_id: current_user.id)
+        SyncItemMetadata.call(item: item, user_id: current_user.id)
       else
         flash[:error] = I18n.t("errors.barcode_not_valid", barcode: item_barcode)
       end
@@ -258,11 +258,11 @@ class TraysController < ApplicationController
       return
     end
 
-    if @tray.items.include?(@item)
+    if @tray.items.include?(item)
       @scanned.push(item_barcode)
     else
-      but_message = @item.tray.present? ? "but is associated with tray '#{@item.tray.barcode}'" : "but is not associated with a tray."
-      AddIssue.call(item: @item,
+      but_message = item.tray.present? ? "but is associated with tray '#{item.tray.barcode}'" : "but is not associated with a tray."
+      AddIssue.call(item: item,
                     user: current_user,
                     type: "tray_mismatch",
                     message: "Item failed QC. Was physically in tray '#{@tray.barcode}', #{but_message}")

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,5 @@
 class Issue < ActiveRecord::Base
-  ISSUE_TYPES = ["not_found", "not_for_annex", "aleph_error", "not_valid_barcode"].freeze
+  ISSUE_TYPES = ["not_found", "not_for_annex", "aleph_error", "not_valid_barcode", "tray_mismatch"].freeze
 
   validates :barcode, presence: true
   validates :issue_type, presence: true, inclusion: ISSUE_TYPES

--- a/app/views/trays/check_items.html.haml
+++ b/app/views/trays/check_items.html.haml
@@ -1,0 +1,44 @@
+.scan
+  = form_tag check_items_validate_path(@tray) do
+    - if @tray.errors.any?
+      #error_explanation
+        %h2= "#{pluralize(@tray.errors.count, "error")} prohibited this tray from being saved:"
+        %ul
+          - @tray.errors.full_messages.each do |msg|
+            %li= msg
+    .field
+      = label_tag :barcode, "Item"
+      = text_field_tag :barcode, '', autofocus: true
+      - @scanned.each do |scan|
+        = hidden_field_tag "scanned[]", scan
+    .actions
+      = submit_tag 'Save', class: 'btn btn-primary'
+
+%table.table.table-striped.condensed{"data-toggle" => "table"}
+  %thead
+    %tr
+      %th= 'Status'
+      %th= 'Barcode'
+      %th= 'Thickness'
+      %th= 'Title'
+      %th= 'Chron'
+  %tbody
+    - @tray.items.each do |item|
+      - class_name = ""
+      - if @scanned.include?(item.barcode)
+        - class_name = "check-items-success"
+
+      %tr{ class: class_name }
+        %td= item.status.titleize
+        %td= link_to item.barcode, item_detail_path(item.barcode)
+        %td= item.thickness
+        %td
+          - if item.metadata_status == "complete"
+            = item.title
+          - else
+            = t "item.metadata_status.#{item.metadata_status}"
+            - if item.title.present?
+              %br
+              = item.title
+        %td= item.chron
+= button_to "Done", check_items_new_path, method: :get, class: 'btn pull-right btn-primary'

--- a/app/views/trays/check_items.html.haml
+++ b/app/views/trays/check_items.html.haml
@@ -14,7 +14,7 @@
     .actions
       = submit_tag 'Save', class: 'btn btn-primary'
 
-%table.table.table-striped.condensed{"data-toggle" => "table"}
+%table.table.table-striped.condensed{ "data-toggle" => "table" }
   %thead
     %tr
       %th= 'Status'

--- a/app/views/trays/check_items_new.html.haml
+++ b/app/views/trays/check_items_new.html.haml
@@ -1,0 +1,14 @@
+.scan
+  = form_for @tray, url: check_items_path(@tray) do |f|
+    - if @tray.errors.any?
+      #error_explanation
+        %h2= "#{pluralize(@tray.errors.count, "error")} prohibited this tray from being saved:"
+        %ul
+          - @tray.errors.full_messages.each do |msg|
+            %li= msg
+
+    .field
+      = f.label :barcode, "Tray"
+      = f.text_field :barcode, autofocus: "autofocus"
+    .actions
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -35,6 +35,13 @@
           View Active Batches
         %a.list-group-item{ :href => view_active_transfers_path }
           View Active Shelf Transfers
+      %a.list-group-item.list-group-item-success{ "data-parent" => "#MainMenu",
+        "data-toggle" => "collapse",
+        :href => "#qc" }
+        %span.glyphicon.glyphicon-plus
+        Quality Control
+      #qc.collapse
+        %a.list-group-item{ :href => check_items_new_path } Items in Tray
     %a.list-group-item.list-group-item-success{ "data-parent" => "#MainMenu",
       "data-toggle" => "collapse",
       :href => "#reports" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@
 en:
   errors:
     barcode_not_found: "Barcode %{barcode} not found. Put item with barcode %{barcode} on problem shelf."
+    barcode_not_associated_to_tray: "Barcode %{barcode} is not associated to this tray. Put item with barcode %{barcode} on problem shelf."
     barcode_not_valid: "Barcode \"%{barcode}\" is not valid, please re-scan."
   trays:
     count_items_not_match: "The count you entered and the computer's count did not match.  Recount and enter again."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
   get "trays/items/:id/count_items", to: "trays#count_items", as: "count_tray_item"
   post "trays/items/:id/count_items", to: "trays#count_items", as: "validate_count_tray"
 
+  get "trays/check_items", to: "trays#check_items_new", as: "check_items_new"
+  post "trays/check_items", to: "trays#check_items", as: "check_items"
+  post "trays/check_items/:id", to: "trays#validate_items", as: "check_items_validate"
+
   post "trays/:id/withdraw", to: "trays#withdraw", as: "withdraw_tray"
 
   get "shelves/items", to: "shelves#index", as: "shelves"

--- a/spec/controllers/trays_controller_spec.rb
+++ b/spec/controllers/trays_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe TraysController, :type => :controller do
   let(:user) { FactoryGirl.create(:user, admin: true) }
@@ -53,6 +53,161 @@ RSpec.describe TraysController, :type => :controller do
         expect(controller).to receive(:notify_airbrake).with(kind_of(RuntimeError))
         post :scan, tray: { barcode: "12345" }
         expect(response).to redirect_to(trays_path)
+      end
+    end
+  end
+
+  describe "GET check_items_new" do
+    subject { get :check_items_new }
+
+    it "returns http success" do
+      subject
+      expect(response).to have_http_status(:success)
+    end
+
+    it "assigns tray for the view" do
+      subject
+      expect(assigns(:tray)).not_to eq(nil)
+    end
+  end
+
+  describe "GET check_items" do
+    subject { get :check_items, tray: { barcode: "12345" } }
+
+    it "returns http success" do
+      subject
+      expect(response).to have_http_status(:success)
+    end
+
+    it "finds and assigns tray for the view" do
+      allow(Tray).to receive(:where).with(barcode: "12345").and_return(double(Object, take: "tray"))
+      subject
+      expect(assigns(:tray)).to eq("tray")
+    end
+
+    it "assigns scanned for the view" do
+      subject
+      expect(assigns(:scanned)).to eq([])
+    end
+  end
+
+  describe "POST validate_items" do
+    let(:tray) { instance_double(Tray, items: [item], barcode: "tray barcode") }
+    let(:item) { instance_double(Item, save!: true) }
+    subject { post :validate_items, id: 1, barcode: "barcode" }
+
+    before(:each) do
+      allow(Tray).to receive(:find).and_return(tray)
+    end
+
+    it "returns http success" do
+      subject
+      expect(response).to have_http_status(:success)
+    end
+
+    it "finds and assigns tray for the view" do
+      subject
+      expect(assigns(:tray)).to eq(tray)
+    end
+
+    it "assigns scanned for the view" do
+      subject
+      expect(assigns(:scanned)).to eq([])
+    end
+
+    it "renders check_items" do
+      expect(subject).to render_template(:check_items)
+    end
+
+    context "for an invalid barcode" do
+      it "flashes an error" do
+        post :validate_items, id: 1, barcode: "invalid barcode"
+        expect(flash[:error]).to include("invalid barcode")
+      end
+    end
+
+    context "for a valid barcode thats not found" do
+      subject { post :validate_items, id: 1, barcode: "valid barcode" }
+
+      before(:each) do
+        allow(IsValidItem).to receive(:call).and_return(true)
+        allow(ActivityLogger).to receive(:create_item)
+        allow(AddIssue).to receive(:call)
+        allow(SyncItemMetadata).to receive(:call)
+        allow(Item).to receive(:new).and_return(item)
+      end
+
+      it "creates a new item" do
+        expect(Item).to receive(:new).and_return(item)
+        expect(item).to receive(:save!).and_return(true)
+        subject
+      end
+
+      it "logs a create item" do
+        expect(ActivityLogger).to receive(:create_item).with(item: item, user: user)
+        subject
+      end
+
+      it "adds a tray_mismatch issue" do
+        expect(AddIssue).to receive(:call).
+          with(item: item, user: user, type: "tray_mismatch", message: anything)
+        subject
+      end
+
+      it "syncs metadata" do
+        expect(SyncItemMetadata).to receive(:call).with(item: item, user_id: user.id)
+        subject
+      end
+
+      it "flashes an error" do
+        subject
+        expect(flash[:error]).to include("valid barcode")
+      end
+    end
+
+    context "for a valid item that's not associated with the tray" do
+      let(:tray) { instance_double(Tray, items: [], barcode: "tray barcode") }
+      let(:other_tray) { instance_double(Tray, barcode: "other tray barcode") }
+      let(:item) { instance_double(Item, tray: tray) }
+      subject { post :validate_items, id: 1, barcode: "valid item barcode" }
+
+      before(:each) do
+        allow(Item).to receive(:where).and_return(double(Object, take: item))
+        allow(AddIssue).to receive(:call)
+      end
+
+      it "flashes an error" do
+        subject
+        expect(flash[:error]).to include("valid item barcode")
+      end
+
+      it "adds a tray_mismatch issue when it is not associated with a tray" do
+        allow(item).to receive(:tray).and_return nil
+        expect(AddIssue).to receive(:call).
+          with(item: item, user: user, type: "tray_mismatch", message: /tray barcode/)
+        subject
+      end
+
+      it "adds a tray_mismatch issue with the tray it is associated with" do
+        allow(item).to receive(:tray).and_return other_tray
+        expect(AddIssue).to receive(:call).
+          with(item: item, user: user, type: "tray_mismatch", message: /tray barcode.*other tray barcode/)
+        subject
+      end
+    end
+
+    context "for a valid item that is associated to the tray" do
+      let(:tray) { instance_double(Tray, items: [item], barcode: "tray barcode") }
+      let(:item) { instance_double(Item, tray: tray, barcode: "item barcode") }
+      subject { post :validate_items, id: 1, barcode: "valid item barcode" }
+
+      before(:each) do
+        allow(Item).to receive(:where).and_return(double(Object, take: item))
+      end
+
+      it "adds the item's barcode to the scanned list" do
+        subject
+        expect(assigns(:scanned)).to eq([item.barcode])
       end
     end
   end

--- a/spec/controllers/trays_controller_spec.rb
+++ b/spec/controllers/trays_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe TraysController, :type => :controller do
 
     context "for a valid item that is associated to the tray" do
       let(:tray) { instance_double(Tray, items: [item], barcode: "tray barcode") }
-      let(:item) { instance_double(Item, tray: tray, barcode: "item barcode") }
+      let(:item) { instance_double(Item) }
       subject { post :validate_items, id: 1, barcode: "valid item barcode" }
 
       before(:each) do
@@ -207,7 +207,7 @@ RSpec.describe TraysController, :type => :controller do
 
       it "adds the item's barcode to the scanned list" do
         subject
-        expect(assigns(:scanned)).to eq([item.barcode])
+        expect(assigns(:scanned)).to eq(["valid item barcode"])
       end
     end
   end


### PR DESCRIPTION
Adds a Quality Control menu that allows the user to scan a tray, then scan each item in the tray to make sure the associated items in the system match the items in the physical tray. This does not persist any information about the QC session in the database, so it relies on the view to persist previous scan data. This may change in the future when this becomes part of a workflow, but for now this seems like the simplest approach until we know what that looks like.