### PR TITLE
Items with Issues that won't go away

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,7 +56,8 @@ class ItemsController < ApplicationController
 
   def resolve
     issue = Issue.find(params[:issue_id])
-    ResolveIssue.call(user: current_user, issue: issue)
+    item = Item.where(barcode: issue.barcode).take!
+    ResolveIssue.call(item: item, user: current_user, issue: issue)
 
     redirect_to issues_path
   end

--- a/app/queries/activity_log_query.rb
+++ b/app/queries/activity_log_query.rb
@@ -22,6 +22,7 @@ module ActivityLogQuery
         "DestroyedItem",
         "DissociatedItemAndTray",
         "DissociatedItemAndBin",
+        "ResolvedIssue",
         "ShippedItem"]).
       order(action_timestamp: :desc)
   end
@@ -50,7 +51,7 @@ module ActivityLogQuery
 
   def for_item(item)
     relation.
-      where("data -> 'item' -> 'barcode' ? :barcode", barcode: item.barcode)
+      where("data->'issue'->'barcode' ? :barcode OR data->'item'->'barcode' ? :barcode", barcode: item.barcode)
   end
 
   def for_tray(tray)

--- a/app/services/activity_logger.rb
+++ b/app/services/activity_logger.rb
@@ -102,8 +102,8 @@ class ActivityLogger
     call(action: "RemovedRequest", request: request, user: user)
   end
 
-  def self.resolve_issue(issue:, user:)
-    call(action: "ResolvedIssue", issue: issue, user: user)
+  def self.resolve_issue(item:, issue:, user:)
+    call(action: "ResolvedIssue", item: item, issue: issue, user: user)
   end
 
   def self.resolve_tray_issue(tray:, issue:, user:)

--- a/app/services/resolve_issue.rb
+++ b/app/services/resolve_issue.rb
@@ -1,11 +1,12 @@
 class ResolveIssue
-  attr_reader :issue, :user
+  attr_reader :item, :issue, :user
 
-  def self.call(issue:, user:)
-    new(issue: issue, user: user).resolve
+  def self.call(item:, issue:, user:)
+    new(item: item, issue: issue, user: user).resolve
   end
 
-  def initialize(issue:, user:)
+  def initialize(item:, issue:, user:)
+    @item = item
     @issue = issue
     @user = user
   end
@@ -14,7 +15,7 @@ class ResolveIssue
     issue.resolver = user
     issue.resolved_at = Time.now
     issue.save!
-    ActivityLogger.resolve_issue(issue: issue, user: user)
+    ActivityLogger.resolve_issue(item: item, issue: issue, user: user)
   end
 
 end

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -94,7 +94,8 @@ feature "Items", type: :feature do
       it "can view a list of issues associated with retrieving item data and delete them" do
         @issues = []
         5.times do
-          @issue = FactoryGirl.create(:issue)
+          item = FactoryGirl.create(:item)
+          @issue = FactoryGirl.create(:issue, barcode: item.barcode)
           @issues << @issue
         end
         visit issues_path

--- a/spec/services/activity_logger_spec.rb
+++ b/spec/services/activity_logger_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe ActivityLogger do
   end
 
   context "ResolvedIssue" do
-    let(:arguments) { { issue: issue, user: user } }
+    let(:arguments) { { item: item, issue: issue, user: user } }
     subject { described_class.resolve_issue(**arguments) }
 
     it_behaves_like "an activity log", "ResolvedIssue"

--- a/spec/services/resolve_issue_spec.rb
+++ b/spec/services/resolve_issue_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe ResolveIssue do
+  let(:item) { FactoryGirl.create(:item) }
   let(:issue) { FactoryGirl.create(:issue) }
   let(:user) { FactoryGirl.create(:user) }
-  subject { described_class.call(issue: issue, user: user) }
+  subject { described_class.call(item: item, issue: issue, user: user) }
 
   it "resolves the issue" do
     expect(issue.resolved_at).to be_nil
@@ -14,7 +15,7 @@ RSpec.describe ResolveIssue do
   end
 
   it "logs the issue resolution" do
-    expect(ActivityLogger).to receive(:resolve_issue).with(issue: issue, user: user)
+    expect(ActivityLogger).to receive(:resolve_issue).with(item: item, issue: issue, user: user)
     subject
   end
 end


### PR DESCRIPTION
Its hard to see what's happening to these items in order to identify a pattern since the reports don't show when the issues were resolved (without going into psql and manually querying). Made a few changes to make this easier in the future:
- Added the ResolvedIssue action type to the report for an item.
- Logging of ResolvedIssue action for items is inconsistent with the way other logs are produced. All others expect the associated item to be logged with the action. Changed to require an item when creating a log of this type. Unfortunately, this won't retroactively change logs that are there, so I had to also modify the query to also check if the issue had the item barcode.