### PR TITLE
AIMS-421

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -36,7 +36,7 @@ class BatchesController < ApplicationController
   end
 
   def current
-    @batch = current_user.batches.where(active: true).first
+    @batch = current_user.batches.where(active: true, batch_type: 0).first
 
     if @batch.blank?
       flash[:error] = "#{current_user.username} does not have an active batch, please create one."

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,4 +1,7 @@
 class Batch < ActiveRecord::Base
+
+  enum batch_type: { regular: 0, deaccession_unstocked: 1 }
+
   has_many :matches
   has_many :requests, -> { uniq }, through: :matches
   has_many :items, through: :matches

--- a/app/services/build_batch.rb
+++ b/app/services/build_batch.rb
@@ -1,23 +1,25 @@
 class BuildBatch
-  attr_reader :batch_data, :user
+  attr_reader :batch_data, :user, :batch_type
 
-  def self.call(batch_data, user)
-    new(batch_data, user).build!
+  def self.call(batch_data, user, batch_type = 0)
+    new(batch_data, user, batch_type).build!
   end
 
-  def initialize(batch_data, user)
+  def initialize(batch_data, user, batch_type)
     @batch_data = batch_data
     @user = user
+    @batch_type = batch_type
   end
 
   def build!
-    if user.batches.where(active: true).count == 0
+    if user.batches.where(active: true, batch_type: @batch_type).count == 0
       batch = Batch.new
       batch.user = user
+      batch.batch_type = @batch_type
       batch.active = true
       batch.save!
     else
-      batch = user.batches.where(active: true).first
+      batch = user.batches.where(active: true, batch_type: @batch_type).first
     end
 
     if batch_data.length > 0

--- a/app/services/deaccession_not_stocked_item.rb
+++ b/app/services/deaccession_not_stocked_item.rb
@@ -4,7 +4,7 @@ class DeaccessionNotStockedItem
   end
 
   def deaccession(request_id, item_id, disposition_id, user)
-    batch = BuildBatch.call(["#{request_id}-#{item_id}"], user)
+    batch = BuildBatch.call(["#{request_id}-#{item_id}"], user, 1)
     bin = GetBinFromBarcode.call("BIN-DEAC-HAND-01")
     SetItemDisposition.call(item_id, disposition_id)
     item = Item.where(id: item_id).take

--- a/db/migrate/20171016015953_add_batch_type_to_batch.rb
+++ b/db/migrate/20171016015953_add_batch_type_to_batch.rb
@@ -1,0 +1,5 @@
+class AddBatchTypeToBatch < ActiveRecord::Migration
+  def change
+    add_column :batches, :batch_type, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170604211603) do
+ActiveRecord::Schema.define(version: 20171016015953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20170604211603) do
     t.datetime "updated_at",                null: false
     t.integer  "user_id",                   null: false
     t.boolean  "active",     default: true, null: false
+    t.integer  "batch_type", default: 0,    null: false
   end
 
   add_index "batches", ["user_id"], name: "index_batches_on_user_id", using: :btree


### PR DESCRIPTION
 Matches require a batch, so we needed a new type of batch for deaccessioning unstocked items so they won't show on the batch processing page.