### PR TITLE
Fix for tray labels in item detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ $ bundle install
 $ bundle exec rake db:create db:migrate db:seed
 ```
 
-Start guard; This will fire up the application and also start Solr.
+Start thin; This will fire up the application. Solr, sneakers and Postgres should also be running.
 
 ```console
-$ bundle exec guard
+$ brew services restart postgresql
+$ thin start -C config/thin.yml
+$ rake sunspot:solr:start
+$ brew services start rabbitmq
+$ rake sneakers:start
 ```

--- a/app/queries/activity_log_query.rb
+++ b/app/queries/activity_log_query.rb
@@ -53,7 +53,6 @@ module ActivityLogQuery
 
   def for_item(item)
     relation.
-      # where("data->'issue'->'barcode' ? :barcode OR data->'item'->'barcode' ? :barcode", barcode: item.barcode)
       where("data->'issue'->>'barcode' = ? OR data->'item'->>'barcode' = ? OR data->'item'->>'id' = ?", item.barcode, item.barcode, item.id.to_s)
   end
 

--- a/app/queries/activity_log_query.rb
+++ b/app/queries/activity_log_query.rb
@@ -53,7 +53,8 @@ module ActivityLogQuery
 
   def for_item(item)
     relation.
-      where("data->'issue'->'barcode' ? :barcode OR data->'item'->'barcode' ? :barcode", barcode: item.barcode)
+      # where("data->'issue'->'barcode' ? :barcode OR data->'item'->'barcode' ? :barcode", barcode: item.barcode)
+      where("data->'issue'->>'barcode' = ? OR data->'item'->>'barcode' = ? OR data->'item'->>'id' = ?", item.barcode, item.barcode, item.id.to_s)
   end
 
   def for_tray(tray)
@@ -64,6 +65,12 @@ module ActivityLogQuery
   def for_shelf(shelf)
     relation.
       where("data -> 'shelf' -> 'barcode' ? :barcode", barcode: shelf.barcode)
+  end
+
+  def tray_barcode(record)
+    return record.data['tray']['barcode'] unless record.data['tray'].blank?
+    return Tray.find(record.data['item']['tray_id']).barcode unless record.data['item']['tray_id'].blank?
+    'STAGING'
   end
 
   private_class_method :relation

--- a/app/views/items/item_detail.html.haml
+++ b/app/views/items/item_detail.html.haml
@@ -77,7 +77,6 @@
             %tr
               %td= t("activity_log." + record.action, disposition: !record.data['disposition'].nil? ? record.data['disposition']['code'] : '', comment: !record.data['comment'].nil? ? record.data['comment']['comment'] : '')
               %td= record.action_timestamp.strftime("%m-%d-%Y %I:%M%p")
-              -# %td= (record.data['tray'].blank? && record.data['item']['tray_id'].blank?) ? 'STAGING' : (record.data['tray'].blank? ? Tray.find(record.data['item']['tray_id']).barcode : record.data['tray']['barcode'])
               %td= ActivityLogQuery.tray_barcode(record)
               %td= record.username
   %div.panel.panel-warning

--- a/app/views/items/item_detail.html.haml
+++ b/app/views/items/item_detail.html.haml
@@ -77,7 +77,8 @@
             %tr
               %td= t("activity_log." + record.action, disposition: !record.data['disposition'].nil? ? record.data['disposition']['code'] : '', comment: !record.data['comment'].nil? ? record.data['comment']['comment'] : '')
               %td= record.action_timestamp.strftime("%m-%d-%Y %I:%M%p")
-              %td= record.data['tray'].blank? ? 'STAGING' : record.data['tray']['barcode']
+              -# %td= (record.data['tray'].blank? && record.data['item']['tray_id'].blank?) ? 'STAGING' : (record.data['tray'].blank? ? Tray.find(record.data['item']['tray_id']).barcode : record.data['tray']['barcode'])
+              %td= ActivityLogQuery.tray_barcode(record)
               %td= record.username
   %div.panel.panel-warning
     %div.panel-heading


### PR DESCRIPTION
When the full tray object is not stored in the activity log, the valid tray label was not appearing in the item detail view history. This is a fix for that - added a utility method on the query log class to determine what the label should be no matter what is stored in the activity log