### PR TITLE
AIMS-462

### DIFF
--- a/app/models/concerns/barcode_space_validator.rb
+++ b/app/models/concerns/barcode_space_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BarcodeSpaceValidator < ActiveModel::Validator
+  def validate(record)
+    if record.barcode.present? && record.barcode.match(/\s/)
+      record.errors.add(
+        :barcode, I18n.t('errors.barcode_has_spaces', barcode: record.barcode)
+      )
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,6 +27,7 @@ class Item < ActiveRecord::Base
   validates :barcode, uniqueness: true, presence: true
   validates :metadata_status, inclusion: METADATA_STATUSES
   validate :has_correct_prefix?
+  validates_with BarcodeSpaceValidator
 
   belongs_to :tray
   belongs_to :bin

--- a/app/services/is_valid_item.rb
+++ b/app/services/is_valid_item.rb
@@ -1,5 +1,6 @@
 module IsValidItem
   def self.call(barcode)
+    # This is a terrible way to do this.
     parameter_file = File.join(Rails.root, "config", "barcode_patterns.yml")
     settings = YAML.load(File.open(parameter_file))
     parameters = settings["common"]["parameters"]
@@ -10,6 +11,7 @@ module IsValidItem
     end
 
     # If there is more than one regular expression set, the barcode is valid if it matches any one of them.
+    # And what if you need to fulfill multiple requirements? Terrible.
     parameters.each do |parameter|
       if parameter["enabled"]
         if barcode =~ /^#{parameter["regex"]}(.*)/

--- a/config/barcode_patterns.yml
+++ b/config/barcode_patterns.yml
@@ -4,6 +4,11 @@
 # The parameters need to be stored in such a way that a UI can be built later to manage them
 # It should be possible to "inactivate" a parameter without deleting it (some sort of flag)
 
+# This is a terrible way to do this. Validators belong in the model.
+# Also, if you want to use the UI to handle these, it should be stored in
+# the db, not in a config file.
+# I recommend throwing this away.
+
 common: &defaults
   # The initial barcode parameter should be: 14 digits with no additional
   # characters before or after. Flag (in/de)activates it without deleting it.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
     barcode_not_associated_to_tray: "Barcode %{barcode} is not associated to this tray. Put item with barcode %{barcode} on problem shelf."
     barcode_not_associated_to_shelf: "Barcode %{barcode} is not associated to this shelf. Put tray with barcode %{barcode} on problem shelf."
     barcode_not_valid: "Barcode \"%{barcode}\" is not valid, please re-scan."
+    barcode_has_spaces: "Barcode \"%{barcode}\" has spaces, please re-scan."
   trays:
     count_items_not_match: "The count you entered and the computer's count did not match.  Recount and enter again."
     count_validation_not_pass: "Put Tray to side for QC."

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe Item, type: :model do
       expect(subject.errors[:metadata_status].size).to eq(1)
     end
   end
+
+  it "does not accept barcodes with spaces" do
+    subject.barcode = "12 34567"
+    subject.valid?
+    expect(subject.errors[:barcode].size).to eq(1)
+  end
 end


### PR DESCRIPTION
I'm a bit uncertain on how spaces could have shown up in barcodes, given that the existing validator requires 14 digits. That should exclude spaces. That said, that validator takes place outside the model, so it might be possible for a code path to not hit it.

This validator is inside the model, so should always be hit.

This will be hard to test on its own via the UI, but I wrote a unit test around it.