### PR TITLE
Update capistrano lock version to match gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem "whenever", require: false
 
 group :deployment do
   # Use Capistrano for deployment
-  gem "capistrano", "~> 3.11"
+  gem "capistrano", "= 3.11.2"
   gem "capistrano-maintenance", "~> 1.0"
   gem "capistrano-rails", "~> 1.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.4.1)
   bootstrap_progressbar
   byebug
-  capistrano (~> 3.11)
+  capistrano (= 3.11.2)
   capistrano-maintenance (~> 1.0)
   capistrano-rails (~> 1.1)
   capybara (~> 2.4)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock "3.11.0"
+lock "3.11.2"
 
 require "capistrano/maintenance"
 


### PR DESCRIPTION
This got updated along with the other gems. There don't look to be any breaking changes, so I'm updating the locked version accordingly.