### PR TITLE
Set PTY to true to fix exit status code issue

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -35,7 +35,7 @@ set :ssh_options, {
 # set :log_level, :debug
 
 # Default value for :pty is false
-# set :pty, true
+set :pty, true
 
 # Default value for :linked_files is []
 # set :linked_files, fetch(:linked_files, []).push("config/database.yml")


### PR DESCRIPTION
Setting this value to true allows for the correct exit status to be returned when running capistrano with SShKit - we need to set this so that Jenkins deploys don't hang indefinitely