### PR TITLE
Renaming whitelist to allowed

### DIFF
--- a/app/controllers/deaccessioning_controller.rb
+++ b/app/controllers/deaccessioning_controller.rb
@@ -10,7 +10,7 @@ class DeaccessioningController < ApplicationController
     @criteria_type = params[:criteria_type]
   end
 
-  def params_whitelist
+  def params_allowed
     params.permit(items: {})
     params.permit([:disposition_id, :comment])
   end
@@ -19,22 +19,22 @@ class DeaccessioningController < ApplicationController
     if Disposition.pluck(:id).include?(params[:disposition_id].to_i)
       if params[:items].blank?
         flash[:error] = I18n.t("deaccessioning.status.empty_items")
-        redirect_to(deaccessioning_path(params_whitelist)) && return
+        redirect_to(deaccessioning_path(params_allowed)) && return
       else
         items = Item.where(id: params[:items].keys)
         items.each do |item|
           request = BuildDeaccessioningRequest.call(item.id,
-                                                    params_whitelist[:disposition_id],
-                                                    params_whitelist[:comment])[0]
+                                                    params_allowed[:disposition_id],
+                                                    params_allowed[:comment])[0]
           if !item.stocked?
-            DeaccessionNotStockedItem.call(request.id, item.id, params_whitelist[:disposition_id], current_user)
+            DeaccessionNotStockedItem.call(request.id, item.id, params_allowed[:disposition_id], current_user)
           end
         end
         redirect_to(deaccessioning_path) && return
       end
     else
       flash[:error] = "Select a Disposition"
-      redirect_to(deaccessioning_path(params_whitelist)) && return
+      redirect_to(deaccessioning_path(params_allowed)) && return
     end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -68,7 +68,7 @@ class ReportsController < ApplicationController
     @report = Report.find(params[:id])
   end
 
-  # Never trust parameters from the scary internet, only allow the white list through.
+  # Never trust parameters from the scary internet, only allow the following.
   def report_params
     params.require(:report).permit(:name, :start_date, :end_date, :activity, :status, :fields)
   end


### PR DESCRIPTION
Prior to this commit, our language of Whitelist perpetuated the idea
that "white" is _the_ allowed. This change clarifies the purpose without
relying on discriminatory cultural jargon (e.g. blacklist/whitelist). In
addition, by using a clear term, we make the intention more accessible.